### PR TITLE
Add netlify plugin for running tests

### DIFF
--- a/.netlify/netlify-plugin-jest/index.js
+++ b/.netlify/netlify-plugin-jest/index.js
@@ -1,25 +1,8 @@
 module.exports = {
-  onPreBuild: async ({ utils: { build, run, status } }) => {
+  onPreBuild: async ({ utils: { build, run } }) => {
     try {
       await run.command("yarn test --ci")
-
-      status.show({
-        // Optional. Default to the plugin's name followed by a generic title.
-        title: "Continuous Integration",
-        // Required.
-        summary: "Tests passed"
-        // Optional. Empty by default.
-        // text: 'Detailed information shown in a collapsible section',
-      })
     } catch (error) {
-      status.show({
-        // Optional. Default to the plugin's name followed by a generic title.
-        title: "Continuous Integration",
-        // Required.
-        summary: "Tests failed"
-        // Optional. Empty by default.
-        // text: 'Detailed information shown in a collapsible section',
-      })
       return build.failBuild(error)
     }
   }

--- a/.netlify/netlify-plugin-jest/index.js
+++ b/.netlify/netlify-plugin-jest/index.js
@@ -1,8 +1,25 @@
 module.exports = {
-  onPostBuild: async ({ utils: { build, run } }) => {
+  onPreBuild: async ({ utils: { build, run, status } }) => {
     try {
-      await run.command("yarn test")
+      await run.command("yarn test --ci")
+
+      status.show({
+        // Optional. Default to the plugin's name followed by a generic title.
+        title: "Continuous Integration",
+        // Required.
+        summary: "Tests passed"
+        // Optional. Empty by default.
+        // text: 'Detailed information shown in a collapsible section',
+      })
     } catch (error) {
+      status.show({
+        // Optional. Default to the plugin's name followed by a generic title.
+        title: "Continuous Integration",
+        // Required.
+        summary: "Tests failed"
+        // Optional. Empty by default.
+        // text: 'Detailed information shown in a collapsible section',
+      })
       return build.failBuild(error)
     }
   }

--- a/.netlify/netlify-plugin-jest/index.js
+++ b/.netlify/netlify-plugin-jest/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  onPostBuild: async ({ utils: { build, run } }) => {
+    try {
+      await run.command("yarn test")
+    } catch (error) {
+      return build.failBuild(error)
+    }
+  }
+}

--- a/.netlify/netlify-plugin-jest/manifest.yml
+++ b/.netlify/netlify-plugin-jest/manifest.yml
@@ -1,0 +1,2 @@
+name: netlify-plugin-jest
+inputs: []

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "npm run build"
   publish = "dist"
+
+[[plugins]]
+package = "/.netlify/netlify-plugin-jest"

--- a/src/_includes/components/image/image.spec.js
+++ b/src/_includes/components/image/image.spec.js
@@ -62,4 +62,8 @@ describe("Image Transformer", () => {
     const result = transform({ path: "/my-image.jpg", md: "1500px" })
     expect(result.src).toContain("1500")
   })
+  it("adds height and fit params when specifying ratio", () => {
+    const result = transform({ path: "/my-image.jpg", md: "200px", ratio: "2:1" })
+    expect(result.sources[0].srcset).toContain("w=200&h=100&fit=crop")
+  })
 })

--- a/src/_includes/components/image/image.transformer.js
+++ b/src/_includes/components/image/image.transformer.js
@@ -4,8 +4,6 @@ const lodash = require("lodash")
 /**
  * This is a WIP. I would like to:
  *
- * - Make sure tests are running as part of the build. Consider using a build
- *   plugin to achieve that.
  * - Intrinsic sizing built from a ratio?
  * - Use a data-attribute for src on page load and then using srcset (and an
  *   accompanying js component) ???

--- a/src/_includes/components/image/image.transformer.js
+++ b/src/_includes/components/image/image.transformer.js
@@ -17,7 +17,18 @@ const lodash = require("lodash")
  *
  */
 
-module.exports = ({ xs = "100vw", sm, md, lg, xl, max = 1400, steps = 10, path, ...props }) => {
+module.exports = ({
+  xs = "100vw",
+  sm,
+  md,
+  lg,
+  xl,
+  max = 1400,
+  steps = 10,
+  path,
+  ratio,
+  ...props
+}) => {
   if (!path) {
     console.error("The path argument is required for transforming an image.")
     return props
@@ -30,14 +41,22 @@ module.exports = ({ xs = "100vw", sm, md, lg, xl, max = 1400, steps = 10, path, 
 
   let largestSrc = 0
 
-  const generateUrl = params => client.buildURL(path, { auto: "format,compress", ...params })
+  const generateUrl = width => {
+    let params = { auto: "format,compress", w: width }
+    if (ratio) {
+      const [widthRatio, heightRatio] = ratio.split(":")
+      params["h"] = (width * heightRatio) / widthRatio
+      params["fit"] = "crop"
+    }
+    return client.buildURL(path, params)
+  }
 
   const generateSrcsets = widths => {
     return widths
       .map(width => {
         width = parseInt(width)
         if (width > largestSrc) largestSrc = width
-        return `${generateUrl({ w: width })} ${width}w`
+        return `${generateUrl(width)} ${width}w`
       })
       .join(",")
   }
@@ -109,6 +128,6 @@ module.exports = ({ xs = "100vw", sm, md, lg, xl, max = 1400, steps = 10, path, 
   return {
     ...props,
     sources: lodash.reverse(sources),
-    src: generateUrl({ w: largestSrc / 2 })
+    src: generateUrl(largestSrc / 2)
   }
 }

--- a/src/_includes/components/image/image.transformer.js
+++ b/src/_includes/components/image/image.transformer.js
@@ -4,17 +4,18 @@ const lodash = require("lodash")
 /**
  * This is a WIP. I would like to:
  *
- * - Get it rendering on the front-end
- * - Figure out a default src
- * - Use the <picture> object
+ * - Make sure tests are running as part of the build. Consider using a build
+ *   plugin to achieve that.
  * - Intrinsic sizing built from a ratio?
  * - Use a data-attribute for src on page load and then using srcset (and an
- *   accompanying js component)
+ *   accompanying js component) ???
  * - Or ... maybe use lazy loading (imgix.js has a recommendation on which one
  *   to use)
- * - Clean up the code.
- * - Wrap it up in a plugin?
  * - Write a blog post (specific to imgix)
+ * - Clean up the code. Wrap it up in a plugin? Or maybe a shared library. I
+ *   feel like this could be a utility that is imported and then made into a
+ *   component. That could be a better fit for a blog post, too, because it
+ *   could lead to a series of them.
  *
  */
 


### PR DESCRIPTION
Add support for ratios, add comments, and clean up the image transformer a bit. Also adds netlify plugin for running CI tests.

---

This leaves a bit to be desired. I'd love to add lazy loading, intrinsic sizing and more, but this is where I'm going to start. It's enough for a blog post on the topic and a conversation with imgix to see if there is any value in creating a plugin.