### PR TITLE
[Fixes #95] Remove the option to add tag colors

### DIFF
--- a/src/_includes/components/tag/tag.template.njk
+++ b/src/_includes/components/tag/tag.template.njk
@@ -1,8 +1,8 @@
 <a
   href="{{ url }}"
   class="
-    bg-{{ color }}
-    text-{{ textColor }}
+    bg-gray-200
+    text-gray-800
     p-1
     inline-block
     leading-none

--- a/src/_includes/components/tag/tag.transformer.js
+++ b/src/_includes/components/tag/tag.transformer.js
@@ -3,8 +3,6 @@ const lodash = require("lodash")
 module.exports = ({ tag, ...props }) => {
   return {
     ...props,
-    color: lodash.get(tag, "data.color") || "gray-200",
-    textColor: lodash.get(tag, "data.textColor") || "gray-800",
     label: lodash.get(tag, "data.title"),
     url: tag.url
   }


### PR DESCRIPTION
This removes the ability to add custom tag colors, but that apparently wasn't working in production anyways. My gut here is that if it's something I want to add again in the future, it'll likely be part of a bigger feature (e.g. build out a whole JavaScript experience). In that case, it's going to take some extra testing and the simplistic color solution I had in place may not even serve that new experience.