### PR TITLE
[Fixes #103] Fix back button SVG issues on safari

### DIFF
--- a/src/_includes/components/back_button/back_button.styles.css
+++ b/src/_includes/components/back_button/back_button.styles.css
@@ -3,7 +3,8 @@
     link-transition;
 
   svg {
-    @apply inline-block
+    @apply h-6
+      inline-block
       mr-1
       w-4;
   }

--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -2,11 +2,11 @@
 {% include "layout/header.njk" %}
 
 <div class="py-24">
-  <div class="container max-w-4xl">
+  <div class="container max-w-4xl relative">
     {% back_button href="/blog", label="All Posts", classes="mb-2" %}
     <h1 class="text-4xl leading-snug mb-3">{{ title }}</h1>
     {% if description %}
-      <p class="text-2xl">{{ description }}</p>
+        <p class="text-2xl">{{ description }}</p>
     {% endif %}
     {% if tags.length > 0 %}
       <div class="mt-4 text-sm">


### PR DESCRIPTION
This fixes the first issue with the SVG. It also fixes the selection expanding to the edge _only in the header_ of the post layout.

What I found was that Safari will expand the selection until it hits the edge of a relatively-positioned container. My approach with the code blocks is the what prevents me being able to easily make this fix. It's making me second guess when I really want that style or not. I'm going to open another issue to think about it.