### PR TITLE
[Fixes #104] Add post image to RSS feed

### DIFF
--- a/src/blog/posts/2021-01-10-eleventy-server-components.md
+++ b/src/blog/posts/2021-01-10-eleventy-server-components.md
@@ -127,7 +127,7 @@ Then, in our [Eleventy config file](https://www.11ty.dev/docs/config/), add the 
 `.eleventy.js` {.filename}
 
 ```js
-const fs = require("fs")
+const fs = require("fs")
 const path = require("path")
 const nunjucks = require("nunjucks")
 

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -29,7 +29,12 @@ metadata:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html">
+      {%- if post.data.image %}
+        &lt;p&gt;&lt;img src=&quot;{{ post.data.image | imgix_url({ w: 1400 }) }}&quot;&gt;&lt;/p&gt;
+      {%- endif %}
+      {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}
+    </content>
   </entry>
   {%- endfor %}
 </feed>

--- a/utils/filters/imgix_url.js
+++ b/utils/filters/imgix_url.js
@@ -1,17 +1,29 @@
 const ImgixClient = require("imgix-core-js")
 
 /**
+ * Converts a path to an image in S3 to a full (signed) Imgix URL.
+ *
+ * @param {string} input Path to the image in S3.
+ * @param {object} params Imgix parameters used to manipulate the image.
+ *
+ * @returns Full Imgix URL with signed token
+ */
+exports.imgixUrl = (input, params = {}) => {
+  if (!input) return null
+
+  const client = new ImgixClient({
+    domain: process.env.IMGIX_DOMAIN,
+    secureURLToken: process.env.IMGIX_TOKEN
+  })
+
+  return client.buildURL(input, params)
+}
+
+/**
  * Given a path, it loads the a full Imgix URL.
  *
  * @param {object} eleventyConfig Eleventy's configuration object
  */
 exports.default = eleventyConfig => {
-  eleventyConfig.addFilter("imgix_url", (input, params = {}) => {
-    const client = new ImgixClient({
-      domain: process.env.IMGIX_DOMAIN,
-      secureURLToken: process.env.IMGIX_TOKEN
-    })
-
-    return client.buildURL(input, params)
-  })
+  eleventyConfig.addFilter("imgix_url", (input, params) => this.imgixUrl(input, params))
 }

--- a/utils/filters/imgix_url.spec.js
+++ b/utils/filters/imgix_url.spec.js
@@ -1,0 +1,19 @@
+const { imgixUrl } = require("./imgix_url")
+
+describe("imgixUrl()", () => {
+  test("returns null when there is no input", () => {
+    const result = imgixUrl()
+    expect(result).toEqual(null)
+  })
+  test("returns a full, signed URL", () => {
+    const input = "/blog/210309/wtf--pnpm.png"
+    const result = imgixUrl(input)
+    expect(result).toContain(process.env.IMGIX_DOMAIN)
+    expect(result).toContain(input)
+    expect(result).toContain("&s=")
+  })
+  test("includes the specified parameters", () => {
+    const result = imgixUrl("/blog/210309/wtf--pnpm.png", { auto: "compress,format" })
+    expect(result).toContain("auto=compress%2Cformat")
+  })
+})


### PR DESCRIPTION
This looks for `image` in the frontmatter of a post and prepends it to the post's body in the XML RSS feed.