### PR TITLE
[Fixes #42] Add callout component

### DIFF
--- a/src/_includes/components/callout/callout.styles.css
+++ b/src/_includes/components/callout/callout.styles.css
@@ -1,0 +1,14 @@
+.component--callout {
+  &.theme-warning {
+    background-color: var(--color-callout-warning-bg);
+
+    .component--callout--label {
+      color: var(--color-callout-warning-label);
+    }
+  }
+
+  code {
+    @apply bg-gray-800
+      text-gray-100;
+  }
+}

--- a/src/_includes/components/callout/callout.template.njk
+++ b/src/_includes/components/callout/callout.template.njk
@@ -7,6 +7,6 @@
   </span>
     {% endif %}
 
-    {{ children }}
+    {{ children | safe }}
   </div>
 </div>

--- a/src/_includes/components/callout/callout.template.njk
+++ b/src/_includes/components/callout/callout.template.njk
@@ -1,0 +1,12 @@
+<div class="bg-gray-300 my-8 py-8 text-gray-800 override-body-constraint component--callout{% if type === 'warning' %} theme-warning{% endif %}">
+  <div class="block max-w-2xl px-4 md:mx-auto">
+
+    {% if type %}
+  <span class="block mb-1 uppercase text-xs text-gray-600 font-bold component--callout--label">
+    {{ type }}
+  </span>
+    {% endif %}
+
+    {{ children }}
+  </div>
+</div>

--- a/src/_includes/components/index.css
+++ b/src/_includes/components/index.css
@@ -1,5 +1,6 @@
 @import "./back_button/back_button.styles.css";
 @import "./button/button.styles.css";
+@import "./callout/callout.styles.css";
 @import "./codepen/codepen.styles.css";
 @import "./post_card/post_card.styles.css";
 @import "./typewriter/typewriter.styles.css";

--- a/src/_includes/css/variables.css
+++ b/src/_includes/css/variables.css
@@ -25,6 +25,9 @@
   --color-white: #ffffff;
   --color-yellow: #ffd445;
 
+  --color-callout-warning-bg: #fae8ac;
+  --color-callout-warning-label: #bf9404;
+
   --color-code-block-bg: #1e1e3f;
   --color-code-block-bg: #1e1e3f;
 }

--- a/src/_layouts/post.css
+++ b/src/_layouts/post.css
@@ -144,6 +144,12 @@
     }
   }
 
+  /* --- Callouts --- */
+  .component--callout + .filename,
+  .component--callout + pre {
+    margin-top: -2rem;
+  }
+
   /* --- Block Quotes --- */
   blockquote {
     @apply bg-gray-300

--- a/src/_layouts/post.css
+++ b/src/_layouts/post.css
@@ -145,6 +145,7 @@
   }
 
   /* --- Callouts --- */
+  pre + .component--callout,
   .component--callout + .filename,
   .component--callout + pre {
     margin-top: -2rem;

--- a/src/blog/posts/2018-10-16-es6-build-pipeline-for-middleman-using-gulp.md
+++ b/src/blog/posts/2018-10-16-es6-build-pipeline-for-middleman-using-gulp.md
@@ -164,7 +164,9 @@ Again, you should see your `package.json` file updated with the new packages.
 
 The Gulp configuration goes into a `gulpfile.js` file at the root of the project.
 
-**WARNING!** While I say this is simple, there's a lot of code here, so this may be a bit overwhelming at first glance. To help, I've injected comments throughout the file so you can see what's going on. I encourage you to read through the code and I'll summarize below the block.
+{% callout type="warning" %}
+While I say this is simple, there's a lot of code here, so this may be a bit overwhelming at first glance. To help, I've injected comments throughout the file so you can see what's going on. I encourage you to read through the code and I'll summarize below the block.
+{% endcallout %}
 
 `gulpfile.js` {.filename}
 

--- a/src/blog/posts/2020-04-08-how-to-build-static-api.md
+++ b/src/blog/posts/2020-04-08-how-to-build-static-api.md
@@ -102,7 +102,9 @@ Since you know you're only going to have one object, you could also return the o
 }
 ```
 
-_Note: For the tutorials listed at the end of the article, we're going to stick with the former approach, for consistency._
+{% callout type="note" %}
+For the tutorials listed at the end of the article, we're going to stick with the former approach, for consistency.
+{% endcallout %}
 
 Now let's look at the _automatic_ portion of the API – deploying and hosting it.
 

--- a/src/blog/posts/2020-04-09-building-static-api-nodejs.md
+++ b/src/blog/posts/2020-04-09-building-static-api-nodejs.md
@@ -116,7 +116,9 @@ The `build` command will run our `build` script, which we haven't created yet. A
 
 Here's the full build script, with comments so you can follow what's happening. There's not a ton to it, really. It runs through our data files and parses them. Then it prepares our build directories and writes the parsed data as JSON files in the appropriate location.
 
-_Note: I like to put scripts in a `bin` directory so they are tucked away from the rest of the code. You're welcome to put this script anywhere you'd like, but will need to adjust the `build` script in your `package.json` file to point to the correct location._
+{% callout type="note" %}
+I like to put scripts in a `bin` directory so they are tucked away from the rest of the code. You're welcome to put this script anywhere you'd like, but will need to adjust the `build` script in your `package.json` file to point to the correct location.
+{% endcallout %}
 
 `bin/build.js` {.filename}
 
@@ -193,7 +195,9 @@ Once that's in place, you can run the command directly:
 
     $ ./bin/build.js
 
-_Note: There isn't a ton of benefit from that in this case because we're abstracting the command in a `package.json` script anyways._
+{% callout type="note" %}
+There isn't a ton of benefit from that in this case because we're abstracting the command in a `package.json` script anyways.
+{% endcallout %}
 
 ### Run the Command!
 

--- a/src/blog/posts/2020-05-06-building-static-api-eleventy.md
+++ b/src/blog/posts/2020-05-06-building-static-api-eleventy.md
@@ -116,7 +116,8 @@ Now let's start the Eleventy dev server:
 
 _(You can learn more about command-line usage [here](https://www.11ty.dev/docs/usage/).)_
 
-Note: I typically like to wrap this command up in the `package.json` file so that I only have to remember a simple command like `npm run dev`. To do that, add to the `scripts` section of `package.json`:
+{% callout type="note" %}
+I typically like to wrap this command up in the `package.json` file so that I only have to remember a simple command like `npm run dev`. To do that, add to the `scripts` section of `package.json`:
 
 `package.json` {.filename}
 
@@ -130,6 +131,7 @@ Note: I typically like to wrap this command up in the `package.json` file so tha
 ```
 
 Now I could run `npm run dev` to start the server.
+{% endcallout %}
 
 Once the server is running, check it out on your computer by opening a browser window and navigating to [http://localhost:8080/earworms.json](http://localhost:8080/earworms.json).
 

--- a/src/blog/posts/2020-07-17-introducing-component-adapters-into-gatsby.md
+++ b/src/blog/posts/2020-07-17-introducing-component-adapters-into-gatsby.md
@@ -122,9 +122,11 @@ import CalendarFixtures from "components/calendar/fixtures"
 const calendar = <Calendar {...CalendarFixtures.simple_calendar} />
 ```
 
-_Note: You'd likely have to update your import paths, but the point here is that it will *just work*. There is no data coming from the data source. We're mocking that with a fixture._
+{% callout type="note" %}
+You'd likely have to update your import paths, but the point here is that it will _just work_. There is no data coming from the data source. We're mocking that with a fixture.
 
-_Also note: The `{...}` syntax represents a [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). It's worth looking into if you are unfamiliar with the concept._
+Also, the `{...}` syntax represents a [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). It's worth looking into if you are unfamiliar with the concept.
+{% endcallout %}
 
 ## The Adapter
 
@@ -132,7 +134,9 @@ Ultimately, we know we want to pull data from a data source, which may not match
 
 The adapter is responsible for retrieving and transforming the data. After transformation, it renders the calendar component. In other words, it's a _data wrapper_ for the the main component.
 
-_Quick sidebar: I know I mentioned the *single responsibility principle* above and this deviates from that in retrieving *and* transforming data. If you really want to stick to it, you could create a separate *transformer* file that only focuses on mapping raw data fields to the component. (I'm working on a smart version of that but am not there yet, so I'm currently shoving both of those responsibilities into the component adapter.)_
+{% callout type="sidebar" %}
+I know I mentioned the _single responsibility principle_ above and this deviates from that in retrieving _and_ transforming data. If you really want to stick to it, you could create a separate _transformer_ file that only focuses on mapping raw data fields to the component. (I'm working on a smart version of that but am not there yet, so I'm currently shoving both of those responsibilities into the component adapter.)
+{% endcallout %}
 
 Let's assume that we have a GraphQL query we can run in our Gatsby project called `allEvents` that returns all the events. Except the properties don't quite match what we'd expect. Instead of `starts` and `ends`, we have `starts_at` and `ends_at`. So we can do something like this:
 

--- a/src/blog/posts/2020-07-30-building-static-api-middleman.md
+++ b/src/blog/posts/2020-07-30-building-static-api-middleman.md
@@ -135,11 +135,13 @@ Now, refreshing the page, you should see the count of `3` nested within a `meta`
     src="/blog/200730/earworms-meta-count.png",
     alt="Earworms - Meta Count" %}
 
-_Note: I like using a Chrome extension to format JSON for me. It's called [JSON Formatter](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en). It cleans up the output to look like this:_
+{% callout type="note" %}
+I like using a Chrome extension to format JSON for me. It's called [JSON Formatter](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en). It cleans up the output to look like this:
 
 {% post_image
     src="/blog/200730/earworms-meta-count-formatted.png",
     alt="Earworms - Meta Count, Formatted Code" %}
+{% endcallout %}
 
 ### Add the Earworms Data
 

--- a/src/blog/posts/2021-03-17-git-list-all-config-options.md
+++ b/src/blog/posts/2021-03-17-git-list-all-config-options.md
@@ -12,7 +12,9 @@ To see all the configuration options available to you, you can [use the referenc
 
     $ git help -c
 
-_Note: If this command doesn't work for you, you likely have to upgrade Git. [Here's a nice guide](https://medium.com/@katopz/how-to-upgrade-git-ff00ea12be18) on how to do that on Mac._
+{% callout type="note" %}
+If this command doesn't work for you, you likely have to upgrade Git. [Here's a nice guide](https://medium.com/@katopz/how-to-upgrade-git-ff00ea12be18) on how to do that on Mac.
+{% endcallout %}
 
 ### Filtering the Results
 

--- a/src/blog/posts/2021-03-18-git-set-default-branch.md
+++ b/src/blog/posts/2021-03-18-git-set-default-branch.md
@@ -20,8 +20,8 @@ But, now Git has a newer config option available in which you can set the defaul
 
     $ git config --global init.defaultBranch main
 
+{% callout type="note" %}
+You need to be on a newer version of Git for this to work. [See here for determining if you have the option available](/blog/git-list-all-config-options). If you don't and the command doesn't work for you, you likely have to upgrade Git. [Here's a nice guide](https://medium.com/@katopz/how-to-upgrade-git-ff00ea12be18) on how to do that on Mac.
+{% endcallout %}
+
 And now every time you run `git init`, the branch Git will provide you will be `main`!
-
----
-
-Note: You need to be on a newer version of Git for this to work. [See here for determining if you have the option available](/blog/git-list-all-config-options). If you don't and the command doesn't work for you, you likely have to upgrade Git. [Here's a nice guide](https://medium.com/@katopz/how-to-upgrade-git-ff00ea12be18) on how to do that on Mac.

--- a/src/blog/posts/2021-03-19-use-pnpm-with-netlify.md
+++ b/src/blog/posts/2021-03-19-use-pnpm-with-netlify.md
@@ -50,7 +50,9 @@ Next, we'll want to install PNPM. Since NPM is already installed, you can actual
 
 Netlify should run this automatically before running `build`. This will use a remote version of PNPM to install your packages.
 
-Note: This is where I ended up running into trouble. I had other processes that were running prior to the `prebuild` script. That's why I ended up going the plugin route.
+{% callout type="note" %}
+This is where I ended up running into trouble. I had other processes that were running prior to the `prebuild` script. That's why I ended up going the plugin route.
+{% endcallout %}
 
 But if this works for you, that's great! You can use `npm` to run your build scripts just as you would have otherwise, but now you've used `pnpm` to manage your dependencies. You can be confident that the packages you're using in production are the same as those you use to develop locally.
 


### PR DESCRIPTION
This adds a generic callout component. Anything can be passed as the `type` and will appear as the label. If `warning` is passed to the type, it changes the callout to yellow.

I see this evolving over time, but I at least wanted to get some style out there for starters and figured I could iterate on it after that.

_Sidebar: The more I work on components, the more I want to get a component-based library rendering server-side components._