### PR TITLE
Better styling for the keep reading section

### DIFF
--- a/www/src/_includes/components/post_card/post_card.styles.css
+++ b/www/src/_includes/components/post_card/post_card.styles.css
@@ -1,17 +1,38 @@
-.component--post-card[data-layout="horizontal"] {
-  @apply max-w-md;
-
-  .post-card--description {
-    display: none;
-  }
+.component--post-card.layout-horizontal {
+  @apply max-w-lg;
 }
 
 @screen sm {
-  .component--post-card[data-layout] {
+  .component--post-card.layout {
     @apply max-w-xl;
   }
 
-  .component--post-card[data-layout="horizontal"] {
+  .component--post-card.layout-horizontal,
+  .component--post-card.sm\:layout-horizontal {
+    @apply grid;
+
+    grid-template-columns: 12rem 1fr;
+  }
+}
+
+@screen md {
+  .component--post-card.md\:layout-vertical {
+    @apply block;
+  }
+
+  .component--post-card.md\:layout-horizontal {
+    @apply grid;
+
+    grid-template-columns: 12rem 1fr;
+  }
+}
+
+@screen lg {
+  .component--post-card.lg\:layout-vertical {
+    @apply block;
+  }
+
+  .component--post-card.lg\:layout-horizontal {
     @apply grid;
 
     grid-template-columns: 12rem 1fr;

--- a/www/src/_includes/components/post_card/post_card.template.njk
+++ b/www/src/_includes/components/post_card/post_card.template.njk
@@ -1,4 +1,4 @@
-<div class="component--post-card max-w-xl mb-6 bg-white shadow-sm" data-layout="{{ layout }}">
+<div class="component--post-card max-w-xl bg-white shadow-sm {{ classes }}">
   {% if image %}
     <div class="post-card--image-wrapper">
       {{ image | safe }}

--- a/www/src/_includes/components/post_card/post_card.transformer.js
+++ b/www/src/_includes/components/post_card/post_card.transformer.js
@@ -1,7 +1,7 @@
 const lodash = require("lodash");
 const { Component } = require("../../../../utils/shortcodes/component");
 
-module.exports = ({ post, layout = "vertical" }) => {
+module.exports = ({ post, classes = "mb-6" }) => {
   const tagData = lodash.get(post, "data.hashtags") || [];
 
   const tags = tagData
@@ -31,9 +31,9 @@ module.exports = ({ post, layout = "vertical" }) => {
 
   return {
     ...post,
+    classes,
     author,
     image,
     tags,
-    layout,
   };
 };

--- a/www/src/_layouts/post.njk
+++ b/www/src/_layouts/post.njk
@@ -1,8 +1,8 @@
 {% include "layout/head.njk" %}
 {% include "layout/header.njk" %}
 
-<div class="pt-12 pb-24">
-  <div class="layout--post--grid">
+<div class="py-12">
+  <div class="layout--post--grid mb-12">
     {# --- Left Column --- #}
     <div><!-- --></div>
 
@@ -42,16 +42,6 @@
           </div>
         </div>
       </div>
-
-      {% if related_posts.length !== 0 %}
-        <div class="max-w-md sm:max-w-xl mx-auto px-4 mt-12">
-          <h3 class="subheading">More Reading</h3>
-
-          {% for post in collections.posts | get_related_posts(related_posts, tags, page.fileSlug, content) %}
-            {% post_card post=post, layout="horizontal" %}
-          {% endfor %}
-        </div>
-      {% endif %}
     </div>
 
     {# --- Right Column --- #}
@@ -65,6 +55,19 @@
       </div>
     </div>
   </div>
+
+  {% if related_posts.length !== 0 %}
+    <div class="max-w-md md:max-w-xl lg:max-w-7xl mx-auto px-4 py-12">
+      <h3 class="subheading">Keep Reading</h3>
+
+      <div class="grid gap-4 grid-cols-1 lg:grid-cols-3">
+        {% for post in collections.posts | get_related_posts(related_posts, tags, page.fileSlug, content) %}
+          {% post_card post=post, classes="mb-0 md:layout-horizontal lg:layout-vertical" %}
+        {% endfor %}
+      </div>
+
+    </div>
+  {% endif %}
 </div>
 
 {% include "layout/footer.njk" %}


### PR DESCRIPTION
Use vertical cards where it looks good. Removes the `layout` option for post cards in favor of passing layout classes directly. It also no longer hides the description on horizontal cards.