### PR TITLE
Don't cache dynamic imports

### DIFF
--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -28,6 +28,9 @@ const getUtilFiles = () => {
   // Ensure that they are configured correctly. Remove and log a message for
   // those that are not configured properly.
   files = files.map((file) => {
+    // Delete the imported file from the require cache. This brings in updates
+    // if the dev server is already running.
+    delete require.cache[require.resolve(file)];
     // Import the file.
     const module = require(file);
     // If everything looks good, return the module.


### PR DESCRIPTION
There are two places where I am requiring files dynamically. Previously, they were being required on the initial build, but then not re-required if their content changed. Now I'm first deleting them from the require cache and the re-requiring them. Tested on both a component template and transformer and working well.

Ref #288 