### PR TITLE
Add robots.txt file that disallows demos

### DIFF
--- a/www/static/robots.txt
+++ b/www/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /demos/
+
+Sitemap: https://www.seancdavis.com/sitemap.xml


### PR DESCRIPTION
This is a first attempt at solving #322. It adds a `robots.txt` file that should ignore the demos. The file also explicitly specifies the sitemap.

## Sitemap Approach

I looked into the sitemap approach, but the demos were already being excluded for whatever reason.

## Front End Approach

I decided not to look into this. Doesn't seem worth the effort, assuming `robots.txt` works.

## Ignoring Reposts

I also found out that the crawler is ignore reposts. I wish that wasn't the case, but there's no way to configure the crawler with how I set it up today. This is something I could look into, but it's not high priority, so I'm going to let it be.

## Crawler Results

These were the last crawler results. I'll have to merge this before I can ensure that it was working. The ignored pages should increase by four.

<img width="358" alt="Screen Shot 2022-02-02 at 6 33 26 AM" src="https://user-images.githubusercontent.com/5245089/152146098-326c2b42-137a-4c0b-8e6d-cef420adef83.png">
 