### PR TITLE
Guesting Writing, Sponsorship, and Hire Me pages

### DIFF
--- a/www/src/_data/footer_menus.json
+++ b/www/src/_data/footer_menus.json
@@ -38,6 +38,10 @@
       {
         "label": "GitHub",
         "url": "https://github.com/seancdavis"
+      },
+      {
+        "label": "Hire Me",
+        "url": "/hire-me"
       }
     ]
   },

--- a/www/src/_data/header_menu.json
+++ b/www/src/_data/header_menu.json
@@ -15,6 +15,11 @@
     "button": false
   },
   {
+    "label": "Contribute / Hire",
+    "url": "/content-for-developers",
+    "button": false
+  },
+  {
     "label": "Search",
     "url": "/search",
     "icon": "search",

--- a/www/src/pages/about.md
+++ b/www/src/pages/about.md
@@ -100,6 +100,6 @@ timeline:
         - After six months, I was presented with a dream job at [Stackbit](https://www.stackbit.com/), and that's where I am today.
         - Somewhere in all that chaos, my second kid (Walter) was born.
 map:
-  subheading: Building and writing in
+  subheading: Creating content in
   heading: Cincinnati, Ohio (US)
 ---

--- a/www/src/pages/contact.md
+++ b/www/src/pages/contact.md
@@ -21,6 +21,6 @@ Here are a few ways to get in touch.
 
 Here are responses to frequent messages I receive:
 
-- **Guest Writing:** See [the guest writing page](/guest-writing/) for more info.
-- **Sponsorships:** There is no sponsorship program today. If you want to promote something that is helpful to developers, [send your pitch](/guest-writing/).
-- **Freelance Work:** I'm not taking on any development work right now. I consider teaching and writing gigs. Get in touch for details.
+- **Guest Writing:** I love having new and returning contributors to the site! See [the _guest writing_ page](/guest-writing/) for more info.
+- **Sponsorships:** There are a few forms of sponsorship available. See [the _sponsorships_ page](/sponsorship/) for details.
+- **Freelance Work:** I'm not taking on any development work right now, but I am considering other types of work. See [the _hire me_ page](/hire-me/) for more info.

--- a/www/src/pages/content-for-developers.md
+++ b/www/src/pages/content-for-developers.md
@@ -1,0 +1,28 @@
+---
+title: Content for Developers
+description: There are a number of ways to create your content or get it created for you.
+heading: Content for Developers
+subheading: There are a number of ways to create your content or get it created for you.
+seo:
+  image: pages/seancdavis--meta--blank.png
+---
+
+From getting started writing content for developers to having a professional create content on your behalf, this site can be a great resources.
+
+There are a few ways and resources for getting started:
+
+### Sponsorship
+
+I have [a sponsorship program](/sponsorship/) that ranges from a promoted post to content created on your behalf.
+
+### Guest Writing
+
+Whether you've never written an articles or have been writing for decades, this website can be a great outlet for your content.
+
+It's also a great way to contribute open-source content to better the web.
+
+[Learn more about guest writing](/guest-writing/) for this site.
+
+### Hire Me
+
+Sean is also available for hire for content-specific tasks. Details on the preferred arrangement, work, and payment can be found on [the _hire me_ page](/hire-me/)

--- a/www/src/pages/guest-writing.md
+++ b/www/src/pages/guest-writing.md
@@ -9,6 +9,12 @@ seo:
 
 This site is all about helping developers build better websites through tips, tricks, tutorials, and more. You can become [an open-source contributor](/contributors/) by writing content for the site.
 
+{% callout type="note" %}
+
+If you're looking to add content to the site that promotes a product or brand, please begin by reading [the _sponsorship_ page](/sponsorship/).
+
+{% endcallout %}
+
 ## Level Up Your Skills by Teaching
 
 Writing _anywhere_ is great for these reasons:

--- a/www/src/pages/guest-writing.md
+++ b/www/src/pages/guest-writing.md
@@ -7,24 +7,24 @@ seo:
   image: pages/seancdavis--meta--blank.png
 ---
 
-This site is all about content. Content that helps developers build better websites through tips, tricks, tutorials, and so much more.
-
-It is [the contributors](/contributors/) that really make this site what it is.
+This site is all about helping developers build better websites through tips, tricks, tutorials, and more. You can become [an open-source contributor](/contributors/) by writing content for the site.
 
 ## Level Up Your Skills by Teaching
 
-Many developers who begin writing start their own blog or publish on a platform like [Dev.to](https://dev.to/) or [Hashnode](https://hashnode.com/). Writing _anywhere_ is great for these reasons:
+Writing _anywhere_ is great for these reasons:
 
 - The fastest way to learn is to teach. Writing a guide on some particular topic forces the author to truly understand the topic.
-- The best way to get better at writing is to write. Writing is an essential form of communication.
+- The best way to get better at writing is to write. Writing is an essential form of communication in a remote, asynchronous world.
 - Writing forces writers to be a bit vulnerable. To open themselves up to criticism, to confront a lack of knowledge or understanding in some area. It's a great strengthening and growing exercise.
 
 Whatever your topic and platform of choice, I encourage you to put your writing somewhere, even if it's not on this site.
 
-Writing for this site provides some additional benefits:
+## Writing for this Site
 
-- **Professional editing:** Sean is a professional technical writer and will work directly with you to build a publishable piece with your name on it.
-- **Widen your influence:** Adding another site on which you've been published helps spread your influence a bit farther. By publishing here, you unlock a potentially new audience.
+Writing for this site provides additional benefits:
+
+- **Professional editing:** Sean is a professional technical writer and developer who will work directly with you to build a publishable piece with your name on it.
+- **Widen your influence:** Adding another site on which you've been published helps spread your influence a bit farther. By publishing here, you can add to your audience and increase SEO for your other content.
 - **No maintenance:** You can publish and then walk away. No need to maintain the site or the content.
 - **Established cadence:** When you write in your own space, you're the only one who can maintain the frequency of content that readers expect. Here you're part of a site that is publishing other pieces to keep readers coming back.
 
@@ -32,8 +32,8 @@ Writing for this site provides some additional benefits:
 
 Here's how the process works:
 
-1. **Pitch:** To get started, [send an email to Sean](mailto:hello@seancdavis.com) with a brief summary of what you'd like to contribute. Include details like the audience, difficulty, and goals for the piece. See below for types of content that is accepted. _Note: There's a long backlog of ideas, too. You're welcome to ask for a few topics to get started._
-1. **Outline (recommended):** Though optional, after choosing a topic, you may submit an outline for review. This is a great way to ensure your piece is focused before spending time writing. Continue to communicate via email, but use a platform suitable for collaboration for your outline, such as Notion, Dropbox Paper, or Google Docs.
+1. **Pitch:** To get started, [send an email to Sean](mailto:hello@seancdavis.com) with a brief summary of what you'd like to contribute. Include details like the audience, difficulty, and goals for the piece. See below for [types of content](#type-of-content) that is accepted. _Note: There's a long backlog of ideas, too. You're welcome to ask for a few topics to get started._
+1. **Outline (recommended):** Though optional, after choosing a topic, you may submit an outline for review. This is a great way to ensure your piece is focused before spending time writing. Continue to communicate via email, but use a platform suitable for collaboration for your outline, such as Notion, Dropbox Paper, or Google Docs. (We prefer Notion.)
 1. **Draft:** Using the same platform as with your outline, submit a draft via email.
 1. **Review:** Sean will review and leave comments. It may take several iterations to get it right. You may open a reviewed document and see comments all over the place. This is good — it means your piece is going to come out better. But it may take some work to improve. But they are just suggestions and this is your piece. You can always choose to not accept the suggestion.
 1. **Publish:** When your piece is in good shape, Sean will prep and schedule it for publishing. Before publishing, you'll want to provide some profile details.

--- a/www/src/pages/hire-me.md
+++ b/www/src/pages/hire-me.md
@@ -1,0 +1,65 @@
+---
+title: Hire Me
+description: I'm available for writing, teaching, speaking, and consultation.
+heading: Hire Me
+subheading: I'm available for writing, teaching, speaking, and consultation.
+seo:
+  image: pages/seancdavis--meta--blank.png
+---
+
+I get a lot of requests for work. I'm happy to help, but I'm not always available. If you're interested in working together, look at the process and types of work I do below. If you think we're a good fit, [let's talk](/contact).
+
+## Types of Work
+
+I've been hired for many different types of work. Today I limit this to content creation (writing, teaching, speaking), documentation, and consultation.
+
+### Writing
+
+Writing blog posts is my bread and butter. I've been published on a number of places: [CSS-Tricks](https://css-tricks.com/author/seancdavis/), [LogRocket](https://blog.logrocket.com/author/seandavis/), [Sanity](https://www.sanity.io/exchange/community/seancdavis), [Stackbit](https://www.stackbit.com/blog), [Ample](https://www.ample.co/blog-authors/sean-c-davis), [Grouparoo](https://www.grouparoo.com/blog/author/seancdavis).
+
+I can cover a wide range of topics. Today, I'm mostly focused on building modern websites, which can include architecture, development, and design. I'd suggest looking through [the posts](/posts) or [topics](/topics) on this site for an idea of what I've been writing about lately, while noting that I'm always open to new topics.
+
+### Documentation
+
+A big part of my full-time job is writing documentation. I currently write and maintain [Stackbit's documentation](https://docs.stackbit.com/). Generally, I prefer documenting developer tools, but I'm open to other types of documentation.
+
+### Consultation
+
+Much of the freelance work I've done in the last couple years has had a consultation element to it. This is often to support new startups on building their website or product. Or it's been to help clients who are updating their website, moving from an older system to more modern technology.
+
+### Teaching & Speaking
+
+I'm open to teaching workshops and courses, or to giving talks at meetups or conferences. I've done both in the past, and I'm happy to discuss your needs.
+
+## Contracting Process
+
+If your work falls into one of the categories below and you are interested in working together, here's how it typically works:
+
+### Booking Time
+
+Clients (you) book my time in weeks. This typically maxes out at two weeks per month (per client).
+
+### Pricing & Productivity
+
+I charge is $1,500 per week of work.
+
+To give you an idea of productivity, here's the output you can expect:
+
+- **Blog Posts:** Roughly 2k words per week. In other words, this usually means about 2-3 short posts, one longer post. Extra long posts or posts that involve a lot of research or code often span multiple weeks. For example, I wrote an _ultimate guide_ type of post that took me four weeks to write and was about 8.5k words.
+- **Documentation:** Much more difficult to estimate, as it depends on the type and complexity of the documentation. There will also likely be a period of learning for the first couple weeks, in which I won't be as productive.
+- **Teaching/Speaking:** This varies greatly depending on the scope of what you'd like to accomplish.
+- **Consultation:** It often makes more sense to use an hourly contract for this type of work, but that also varies depending on your needs. I'd be [happy to discuss](/contact).
+
+### Payment
+
+Before working together, the first week must be paid in advance. Following that, I invoice monthly. Most clients pay me via their company's ACH system. The service I use also accepts credit cards, checks, and PayPal.
+
+### Contracting
+
+I can provide my own contract or adapt to yours. I'm also happy to work directly with your legal team to make sure we're all on the same page.
+
+My preference with contracts is that they are short and simple. I'm generally happy to give up ownership to the work I do on your behalf (only within the scope of that project).
+
+### Adapting to Your Needs
+
+These are my preferences. But I can be flexible. If you have a different process, I'm happy to [have a chat](/contact) to see if we'd be a good fit.

--- a/www/src/pages/sponsorship.md
+++ b/www/src/pages/sponsorship.md
@@ -7,34 +7,34 @@ seo:
   image: pages/seancdavis--meta--blank.png
 ---
 
-My long-term goal for this site is for it to become self-sustaining. To not be just a side project, but something that I can spend more of each day developing. And to be able to pay those contributing to the project.
+Most of the messages I receive are about getting sponsored content onto the site. The sections below describe how I work with sponsored content.
 
-One means of working toward that goal is by accepting sponsorship. Listed below are the opportunities currently available. If you don't see what you're looking for, [let's chat](/contact).
+## Link Sharing
 
-## Newsletter Sponsor
+I'm open to mutual link sharing to boost our collective SEO **if it is relevant to the content.** I will not add spammy links to this site, nor would I like my site linked to in spammy ways.
 
-I send a monthly newsletter called [_The Spinneret_](/topics/spinneret/). There are plans to overhaul this newsletter in 2022. The new format will include sponsorship opportunities.
+To add your link to this site, you can:
 
-If you'd like to be sponsored in the newsletter in its current format, please [contact me](/contact).
+- [Open a pull request](https://github.com/seancdavis/seancdavis-com#contributing) with your link on the appropriate post.
+- [Send me a message](/contact) with the link you'd like to share and the exact post and location in which it should be placed.
 
-## Guest Post
+Before accepting the request, you must also tell me where on your site you are linking back to my site. This must also be relevant to your audience and not spammy.
+
+## Sponsored Content
 
 I do accept sponsored content. You can contribute a post to the site that promotes your project or product.
 
-To do so, follow [the guest writing guide](/guest-writing), but note when you submit your proposal that it is a sponsored post.
+To do so, follow [the guest writing guide](/guest-writing), but note when you submit your proposal that it is a sponsored post. Note: Sponsored content must still adhere to the guidelines of the content on this site. It must _help developers build better websites through tips, tricks, tutorials, and so much more_.
 
-Note: Sponsored content must still adhere to the guidelines of the content on this site. It must _help developers build better websites through tips, tricks, tutorials, and so much more_.
+Cost is $250 per post, which covers:
 
-Cost is negotiable at this time.
+- My time editing and publishing the post.
+- A mention of the post on Twitter.
 
 ## Writing on Your Behalf
 
-I'm also available to write content that promotes your product or project on your behalf. This content can be published on this site or other platforms or publications.
-
-My rate is $175 per hour, which comes out to about $750-1k for the typical post.
+I'm also available to write content that promotes your product or project on your behalf. This content can be published on this site or other platforms or publications. See [the _hire me_ page](/hire-me) for details.
 
 ## Advertisements
 
-At this time, I do not have a mechanism to introduce ads on the site, and I'm not looking to implement one just yet.
-
-If I can introduce ads in a non-obtrusive way and allow for folks to remove them through subscription, I may consider them in the future. The site must grow considerably in traffic first.
+There are currently no advertisements on this site. I'm open to direct ads. Please [contact me](/contact) for details.


### PR DESCRIPTION
This takes a pass through the existing guest writing and sponsorship pages, while introducing two new pages:
- A page for hiring me — the work I want to do with rates and preferred arrangements
- A page that summarizes all three content-related contribution pages

I added links in the footer, but also one in the header. I think having that visibility will be important.

Eventally, I want to think about how these can be worked into CTAs used in posts. But this is good enough to get started.