### PR TITLE
Cleanup while looking for block map bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .envrc
 node_modules
 yarn-error.log
+
+# Local Netlify folder
+.netlify

--- a/packages/notion-post-publisher/scripts/find-page-by-id.js
+++ b/packages/notion-post-publisher/scripts/find-page-by-id.js
@@ -1,0 +1,19 @@
+const { Client } = require("@notionhq/client");
+
+const notion = new Client({ auth: process.env.NOTION_API_KEY });
+const pageId = process.argv[2];
+
+if (!pageId) {
+  console.error("Usage: node ./scripts/find-page-by-id.js <page-id>");
+  process.exit(1);
+}
+
+// The only pages that will be available are the ones that the API key has
+// access to, which will be the pages in the content database.
+
+(async () => {
+  const response = await notion.pages.retrieve({
+    page_id: pageId,
+  });
+  console.log(response);
+})();


### PR DESCRIPTION
It does seem like there may still be a bug when using blocks that don't render anything. In this case, I tracked down that a post in the test database was using a `ToggleBlock` and we were seeing this error:

```txt
Error:  BlockMap[blockParams.type] is not a constructor
Failed on Notion page: ...
```

This _should_ still be working and just not render anything. However, it's good this got flagged because I could have missed this test post.

In any case, I've added a page debugger and linked up the netlify site with the www project.