### PR TITLE
Block mapping import issue for Notion Post Publisher

### DIFF
--- a/packages/notion-post-publisher/dist/index.js
+++ b/packages/notion-post-publisher/dist/index.js
@@ -4,10 +4,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.publishPosts = publishPosts;
-const Post_1 = require("./lib/Post");
-const notion_utils_1 = require("./utils/notion-utils");
 const chalk_1 = __importDefault(require("chalk"));
-const Logger_1 = require("./lib/Logger");
+const Post_1 = require("./lib/Post");
+const logger_utils_1 = require("./utils/logger-utils");
+const notion_utils_1 = require("./utils/notion-utils");
 /* ----- Main Function ----- */
 /**
  * Finds Notion pages in with the state "Draft: Ready", converts them to
@@ -19,15 +19,15 @@ const Logger_1 = require("./lib/Logger");
  */
 async function publishPosts(config) {
     const pageIds = await (0, notion_utils_1.getPendingPageIds)();
-    const logger = new Logger_1.Logger();
+    logger_utils_1.logger.debug(`Processing ${pageIds.length} pages${pageIds.length > 0 ? ":\n  ⋅ " + pageIds.join("\n  ⋅ ") : "."}`);
     for (const pageId of pageIds) {
         try {
             const post = await Post_1.Post.create(pageId);
             await post.writeToFile(config.postsDir);
-            logger.success(`Added post: ${post.filename}`);
+            logger_utils_1.logger.success(`Added post: ${post.filename}`);
             if (!process.env.SKIP_NOTION_UPDATE) {
                 await (0, notion_utils_1.markPageAsPublished)(pageId, post.date, post.url);
-                logger.success(`Set notion page as published: ${post.title}`);
+                logger_utils_1.logger.success(`Set notion page as published: ${post.title}`);
             }
         }
         catch (err) {

--- a/packages/notion-post-publisher/dist/lib/Block.js
+++ b/packages/notion-post-publisher/dist/lib/Block.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Block = void 0;
+const logger_utils_1 = require("../utils/logger-utils");
 const blocks_1 = require("./blocks");
 const BlockMap = {
     bulleted_list_item: blocks_1.BulletedListItemBlock,
@@ -28,6 +29,7 @@ class Block {
         throw new Error(`Block not supported: ${this.type}`);
     }
     static async create(params) {
+        logger_utils_1.logger.debug(`Creating block: ${params.type}`);
         // If the block is not supported, return an instance of this class, a
         // generic block which throws an error on render.
         if (!Object.keys(BlockMap).includes(params.type)) {

--- a/packages/notion-post-publisher/dist/lib/Block.js
+++ b/packages/notion-post-publisher/dist/lib/Block.js
@@ -36,8 +36,8 @@ class Block {
             return new Block(params.type);
         }
         // Otherwise, pick a block from the map and return a new instance of it.
-        const blockParams = params;
-        const block = new BlockMap[blockParams.type](blockParams);
+        const blockType = params.type;
+        const block = new BlockMap[blockType](blockType);
         // If prerender() exists on the block instance, run it.
         if ("prerender" in block)
             await block.prerender();

--- a/packages/notion-post-publisher/dist/lib/Block.js
+++ b/packages/notion-post-publisher/dist/lib/Block.js
@@ -21,8 +21,6 @@ const BlockMap = {
     toggle: blocks_1.ToggleBlock,
     video: blocks_1.VideoBlock,
 };
-logger_utils_1.logger.debug(Object.keys(BlockMap));
-logger_utils_1.logger.debug(Object.values(BlockMap));
 class Block {
     constructor(type) {
         this.type = type;

--- a/packages/notion-post-publisher/dist/lib/Block.js
+++ b/packages/notion-post-publisher/dist/lib/Block.js
@@ -21,6 +21,8 @@ const BlockMap = {
     toggle: blocks_1.ToggleBlock,
     video: blocks_1.VideoBlock,
 };
+logger_utils_1.logger.debug(Object.keys(BlockMap));
+logger_utils_1.logger.debug(Object.values(BlockMap));
 class Block {
     constructor(type) {
         this.type = type;
@@ -37,7 +39,7 @@ class Block {
         }
         // Otherwise, pick a block from the map and return a new instance of it.
         const blockType = params.type;
-        const block = new BlockMap[blockType](blockType);
+        const block = new BlockMap[blockType](params);
         // If prerender() exists on the block instance, run it.
         if ("prerender" in block)
             await block.prerender();

--- a/packages/notion-post-publisher/dist/lib/Logger.js
+++ b/packages/notion-post-publisher/dist/lib/Logger.js
@@ -9,5 +9,13 @@ class Logger {
     success(msg) {
         console.log(chalk_1.default.green.bold("[success]"), msg);
     }
+    debug(msg) {
+        if (process.env.DEBUG) {
+            console.log(chalk_1.default.blue.bold("[debug]"), msg);
+        }
+    }
+    error(msg) {
+        console.log(chalk_1.default.red.bold("[error]"), msg);
+    }
 }
 exports.Logger = Logger;

--- a/packages/notion-post-publisher/dist/lib/Logger.js
+++ b/packages/notion-post-publisher/dist/lib/Logger.js
@@ -11,7 +11,7 @@ class Logger {
     }
     debug(msg) {
         if (process.env.DEBUG) {
-            console.log(chalk_1.default.blue.bold("[debug]"), msg);
+            console.log(chalk_1.default.blue.bold("[debug]"), String(msg));
         }
     }
     error(msg) {

--- a/packages/notion-post-publisher/dist/lib/blocks/CalloutBlock.js
+++ b/packages/notion-post-publisher/dist/lib/blocks/CalloutBlock.js
@@ -1,8 +1,36 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CalloutBlock = exports.CalloutTypeMap = void 0;
+const logger_utils_1 = require("../../utils/logger-utils");
 const render_utils_1 = require("../../utils/render-utils");
-const Block_1 = require("../Block");
+const BulletedListItemBlock_1 = require("./BulletedListItemBlock");
+const CodeBlock_1 = require("./CodeBlock");
+const DividerBlock_1 = require("./DividerBlock");
+const EmbedBlock_1 = require("./EmbedBlock");
+const Heading1Block_1 = require("./Heading1Block");
+const Heading2Block_1 = require("./Heading2Block");
+const Heading3Block_1 = require("./Heading3Block");
+const ImageBlock_1 = require("./ImageBlock");
+const NumberedListItemBlock_1 = require("./NumberedListItemBlock");
+const ParagraphBlock_1 = require("./ParagraphBlock");
+const QuoteBlock_1 = require("./QuoteBlock");
+const ToggleBlock_1 = require("./ToggleBlock");
+const VideoBlock_1 = require("./VideoBlock");
+const CalloutChildBlockMap = {
+    bulleted_list_item: BulletedListItemBlock_1.BulletedListItemBlock,
+    code: CodeBlock_1.CodeBlock,
+    divider: DividerBlock_1.DividerBlock,
+    embed: EmbedBlock_1.EmbedBlock,
+    heading_1: Heading1Block_1.Heading1Block,
+    heading_2: Heading2Block_1.Heading2Block,
+    heading_3: Heading3Block_1.Heading3Block,
+    image: ImageBlock_1.ImageBlock,
+    numbered_list_item: NumberedListItemBlock_1.NumberedListItemBlock,
+    paragraph: ParagraphBlock_1.ParagraphBlock,
+    quote: QuoteBlock_1.QuoteBlock,
+    toggle: ToggleBlock_1.ToggleBlock,
+    video: VideoBlock_1.VideoBlock,
+};
 exports.CalloutTypeMap = {
     "⚠️": "warning",
     "⚡": "tip",
@@ -40,7 +68,7 @@ class CalloutBlock {
         // Create blocks from children data.
         let childBlocks = [];
         for (const child of this.children) {
-            const block = await Block_1.Block.create(child);
+            const block = await this.createChildBlocks(child);
             childBlocks.push(block);
             // Run prerender if necessary()
             if ("prerender" in block)
@@ -58,6 +86,22 @@ class CalloutBlock {
             throw new Error(msg);
         }
         return `{% callout type="${this.type}" %}\n${this.text}{% endcallout %}`;
+    }
+    async createChildBlocks(params) {
+        logger_utils_1.logger.debug(`Creating child callout block: ${params.type}`);
+        // If the block is not supported, throw an error.
+        if (!Object.keys(CalloutChildBlockMap).includes(params.type)) {
+            throw new Error(`Block not supported: ${params.type}`);
+        }
+        // Otherwise, pick a block from the allowed children and return a new
+        // instance of it.
+        const blockType = params.type;
+        const block = new CalloutChildBlockMap[blockType](params);
+        // If prerender() exists on the block instance, run it.
+        if ("prerender" in block)
+            await block.prerender();
+        // Return the block instance.
+        return block;
     }
 }
 exports.CalloutBlock = CalloutBlock;

--- a/packages/notion-post-publisher/dist/lib/blocks/QuoteBlock.js
+++ b/packages/notion-post-publisher/dist/lib/blocks/QuoteBlock.js
@@ -1,8 +1,34 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.QuoteBlock = void 0;
+const logger_utils_1 = require("../../utils/logger-utils");
 const render_utils_1 = require("../../utils/render-utils");
-const Block_1 = require("../Block");
+const BulletedListItemBlock_1 = require("./BulletedListItemBlock");
+const CodeBlock_1 = require("./CodeBlock");
+const DividerBlock_1 = require("./DividerBlock");
+const EmbedBlock_1 = require("./EmbedBlock");
+const Heading1Block_1 = require("./Heading1Block");
+const Heading2Block_1 = require("./Heading2Block");
+const Heading3Block_1 = require("./Heading3Block");
+const ImageBlock_1 = require("./ImageBlock");
+const NumberedListItemBlock_1 = require("./NumberedListItemBlock");
+const ParagraphBlock_1 = require("./ParagraphBlock");
+const ToggleBlock_1 = require("./ToggleBlock");
+const VideoBlock_1 = require("./VideoBlock");
+const QuoteChildBlockMap = {
+    bulleted_list_item: BulletedListItemBlock_1.BulletedListItemBlock,
+    code: CodeBlock_1.CodeBlock,
+    divider: DividerBlock_1.DividerBlock,
+    embed: EmbedBlock_1.EmbedBlock,
+    heading_1: Heading1Block_1.Heading1Block,
+    heading_2: Heading2Block_1.Heading2Block,
+    heading_3: Heading3Block_1.Heading3Block,
+    image: ImageBlock_1.ImageBlock,
+    numbered_list_item: NumberedListItemBlock_1.NumberedListItemBlock,
+    paragraph: ParagraphBlock_1.ParagraphBlock,
+    toggle: ToggleBlock_1.ToggleBlock,
+    video: VideoBlock_1.VideoBlock,
+};
 class QuoteBlock {
     constructor(params) {
         this.processedChildren = false;
@@ -19,7 +45,7 @@ class QuoteBlock {
         // Create blocks from children data.
         let childBlocks = [];
         for (const child of this.children) {
-            const block = await Block_1.Block.create(child);
+            const block = await this.createChildBlocks(child);
             childBlocks.push(block);
             // Run prerender if necessary()
             if ("prerender" in block)
@@ -37,6 +63,22 @@ class QuoteBlock {
             throw new Error(msg);
         }
         return `> ${this.text}`;
+    }
+    async createChildBlocks(params) {
+        logger_utils_1.logger.debug(`Creating child quote block: ${params.type}`);
+        // If the block is not supported, throw an error.
+        if (!Object.keys(QuoteChildBlockMap).includes(params.type)) {
+            throw new Error(`Block not supported: ${params.type}`);
+        }
+        // Otherwise, pick a block from the allowed children and return a new
+        // instance of it.
+        const blockType = params.type;
+        const block = new QuoteChildBlockMap[blockType](params);
+        // If prerender() exists on the block instance, run it.
+        if ("prerender" in block)
+            await block.prerender();
+        // Return the block instance.
+        return block;
     }
 }
 exports.QuoteBlock = QuoteBlock;

--- a/packages/notion-post-publisher/dist/utils/logger-utils.js
+++ b/packages/notion-post-publisher/dist/utils/logger-utils.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.logger = void 0;
+const Logger_1 = require("../lib/Logger");
+exports.logger = new Logger_1.Logger();

--- a/packages/notion-post-publisher/scripts/search-databases.js
+++ b/packages/notion-post-publisher/scripts/search-databases.js
@@ -6,7 +6,7 @@ const notion = new Client({ auth: process.env.NOTION_API_KEY });
 
 (async () => {
   const response = await notion.search({
-    query: "playground",
+    query: "content",
     filter: {
       property: "object",
       value: "database",

--- a/packages/notion-post-publisher/src/index.ts
+++ b/packages/notion-post-publisher/src/index.ts
@@ -1,7 +1,7 @@
-import { Post } from "./lib/Post";
-import { getPendingPageIds, markPageAsPublished } from "./utils/notion-utils";
 import chalk from "chalk";
-import { Logger } from "./lib/Logger";
+import { Post } from "./lib/Post";
+import { logger } from "./utils/logger-utils";
+import { getPendingPageIds, markPageAsPublished } from "./utils/notion-utils";
 
 /* ----- Types ----- */
 
@@ -21,8 +21,11 @@ type InputConfig = {
  */
 export async function publishPosts(config: InputConfig) {
   const pageIds = await getPendingPageIds();
-  const logger = new Logger();
-
+  logger.debug(
+    `Processing ${pageIds.length} pages${
+      pageIds.length > 0 ? ":\n  ⋅ " + pageIds.join("\n  ⋅ ") : "."
+    }`
+  );
   for (const pageId of pageIds) {
     try {
       const post = await Post.create(pageId);

--- a/packages/notion-post-publisher/src/lib/Block.ts
+++ b/packages/notion-post-publisher/src/lib/Block.ts
@@ -1,22 +1,4 @@
-import type {
-  NotionBlock,
-  NotionBulletedListItemBlock,
-  NotionCalloutBlock,
-  NotionChildPageBlock,
-  NotionCodeBlock,
-  NotionDividerBlock,
-  NotionEmbedBlock,
-  NotionHeading1Block,
-  NotionHeading2Block,
-  NotionHeading3Block,
-  NotionImageBlock,
-  NotionNumberedListItemBlock,
-  NotionParagraphBlock,
-  NotionQuoteBlock,
-  NotionTableOfContentsBlock,
-  NotionToggleBlock,
-  NotionVideoBlock,
-} from "../types/notion";
+import type { NotionBlock } from "../types/notion";
 import { logger } from "../utils/logger-utils";
 
 import {
@@ -37,24 +19,6 @@ import {
   ToggleBlock,
   VideoBlock,
 } from "./blocks";
-
-type SupportedNotionBlocks =
-  | NotionBulletedListItemBlock
-  | NotionCalloutBlock
-  | NotionChildPageBlock
-  | NotionCodeBlock
-  | NotionDividerBlock
-  | NotionEmbedBlock
-  | NotionHeading1Block
-  | NotionHeading2Block
-  | NotionHeading3Block
-  | NotionImageBlock
-  | NotionNumberedListItemBlock
-  | NotionParagraphBlock
-  | NotionQuoteBlock
-  | NotionTableOfContentsBlock
-  | NotionToggleBlock
-  | NotionVideoBlock;
 
 const BlockMap = {
   bulleted_list_item: BulletedListItemBlock,
@@ -113,8 +77,8 @@ export class Block {
       return new Block(params.type);
     }
     // Otherwise, pick a block from the map and return a new instance of it.
-    const blockParams = params as SupportedNotionBlocks;
-    const block = new BlockMap[blockParams.type](blockParams as any);
+    const blockType = params.type as keyof typeof BlockMap;
+    const block = new BlockMap[blockType](blockType as any);
     // If prerender() exists on the block instance, run it.
     if ("prerender" in block) await block.prerender();
     // Return the block instance.

--- a/packages/notion-post-publisher/src/lib/Block.ts
+++ b/packages/notion-post-publisher/src/lib/Block.ts
@@ -17,6 +17,7 @@ import type {
   NotionToggleBlock,
   NotionVideoBlock,
 } from "../types/notion";
+import { logger } from "../utils/logger-utils";
 
 import {
   BulletedListItemBlock,
@@ -105,6 +106,7 @@ export class Block {
   }
 
   static async create(params: NotionBlock): Promise<CreatableBlock> {
+    logger.debug(`Creating block: ${params.type}`);
     // If the block is not supported, return an instance of this class, a
     // generic block which throws an error on render.
     if (!Object.keys(BlockMap).includes(params.type)) {

--- a/packages/notion-post-publisher/src/lib/Block.ts
+++ b/packages/notion-post-publisher/src/lib/Block.ts
@@ -39,9 +39,6 @@ const BlockMap = {
   video: VideoBlock,
 };
 
-logger.debug(Object.keys(BlockMap));
-logger.debug(Object.values(BlockMap));
-
 export type CreatableBlock =
   | Block
   | BulletedListItemBlock

--- a/packages/notion-post-publisher/src/lib/Block.ts
+++ b/packages/notion-post-publisher/src/lib/Block.ts
@@ -39,6 +39,9 @@ const BlockMap = {
   video: VideoBlock,
 };
 
+logger.debug(Object.keys(BlockMap));
+logger.debug(Object.values(BlockMap));
+
 export type CreatableBlock =
   | Block
   | BulletedListItemBlock
@@ -78,7 +81,7 @@ export class Block {
     }
     // Otherwise, pick a block from the map and return a new instance of it.
     const blockType = params.type as keyof typeof BlockMap;
-    const block = new BlockMap[blockType](blockType as any);
+    const block = new BlockMap[blockType](params as any);
     // If prerender() exists on the block instance, run it.
     if ("prerender" in block) await block.prerender();
     // Return the block instance.

--- a/packages/notion-post-publisher/src/lib/Logger.ts
+++ b/packages/notion-post-publisher/src/lib/Logger.ts
@@ -5,9 +5,9 @@ export class Logger {
     console.log(chalk.green.bold("[success]"), msg);
   }
 
-  debug(msg: string) {
+  debug(msg: unknown) {
     if (process.env.DEBUG) {
-      console.log(chalk.blue.bold("[debug]"), msg);
+      console.log(chalk.blue.bold("[debug]"), String(msg));
     }
   }
 

--- a/packages/notion-post-publisher/src/lib/Logger.ts
+++ b/packages/notion-post-publisher/src/lib/Logger.ts
@@ -4,4 +4,14 @@ export class Logger {
   success(msg: string) {
     console.log(chalk.green.bold("[success]"), msg);
   }
+
+  debug(msg: string) {
+    if (process.env.DEBUG) {
+      console.log(chalk.blue.bold("[debug]"), msg);
+    }
+  }
+
+  error(msg: string) {
+    console.log(chalk.red.bold("[error]"), msg);
+  }
 }

--- a/packages/notion-post-publisher/src/lib/blocks/CalloutBlock.ts
+++ b/packages/notion-post-publisher/src/lib/blocks/CalloutBlock.ts
@@ -1,7 +1,42 @@
 import type { NotionBlock, NotionCalloutBlock } from "../../types/notion";
-
+import { logger } from "../../utils/logger-utils";
 import { renderBlocks, renderRichText } from "../../utils/render-utils";
-import { Block, CreatableBlock } from "../Block";
+
+import { BulletedListItemBlock } from "./BulletedListItemBlock";
+import { CodeBlock } from "./CodeBlock";
+import { DividerBlock } from "./DividerBlock";
+import { EmbedBlock } from "./EmbedBlock";
+import { Heading1Block } from "./Heading1Block";
+import { Heading2Block } from "./Heading2Block";
+import { Heading3Block } from "./Heading3Block";
+import { ImageBlock } from "./ImageBlock";
+import { NumberedListItemBlock } from "./NumberedListItemBlock";
+import { ParagraphBlock } from "./ParagraphBlock";
+import { QuoteBlock } from "./QuoteBlock";
+import { ToggleBlock } from "./ToggleBlock";
+import { VideoBlock } from "./VideoBlock";
+
+const CalloutChildBlockMap = {
+  bulleted_list_item: BulletedListItemBlock,
+  code: CodeBlock,
+  divider: DividerBlock,
+  embed: EmbedBlock,
+  heading_1: Heading1Block,
+  heading_2: Heading2Block,
+  heading_3: Heading3Block,
+  image: ImageBlock,
+  numbered_list_item: NumberedListItemBlock,
+  paragraph: ParagraphBlock,
+  quote: QuoteBlock,
+  toggle: ToggleBlock,
+  video: VideoBlock,
+};
+
+type CalloutChildBlockType = keyof typeof CalloutChildBlockMap;
+type CalloutChildBlock =
+  CalloutChildBlockType extends keyof typeof CalloutChildBlockMap
+    ? InstanceType<(typeof CalloutChildBlockMap)[CalloutChildBlockType]>
+    : never;
 
 export const CalloutTypeMap: { [key: string]: string } = {
   "⚠️": "warning",
@@ -47,9 +82,9 @@ export class CalloutBlock {
       return;
     }
     // Create blocks from children data.
-    let childBlocks: CreatableBlock[] = [];
+    let childBlocks: CalloutChildBlock[] = [];
     for (const child of this.children) {
-      const block = await Block.create(child);
+      const block = await this.createChildBlocks(child);
       childBlocks.push(block);
       // Run prerender if necessary()
       if ("prerender" in block) await block.prerender();
@@ -67,5 +102,23 @@ export class CalloutBlock {
       throw new Error(msg);
     }
     return `{% callout type="${this.type}" %}\n${this.text}{% endcallout %}`;
+  }
+
+  private async createChildBlocks(
+    params: NotionBlock
+  ): Promise<CalloutChildBlock> {
+    logger.debug(`Creating child callout block: ${params.type}`);
+    // If the block is not supported, throw an error.
+    if (!Object.keys(CalloutChildBlockMap).includes(params.type)) {
+      throw new Error(`Block not supported: ${params.type}`);
+    }
+    // Otherwise, pick a block from the allowed children and return a new
+    // instance of it.
+    const blockType = params.type as keyof typeof CalloutChildBlockMap;
+    const block = new CalloutChildBlockMap[blockType](params as any);
+    // If prerender() exists on the block instance, run it.
+    if ("prerender" in block) await block.prerender();
+    // Return the block instance.
+    return block;
   }
 }

--- a/packages/notion-post-publisher/src/lib/blocks/QuoteBlock.ts
+++ b/packages/notion-post-publisher/src/lib/blocks/QuoteBlock.ts
@@ -1,11 +1,44 @@
 import type {
-  NotionQuoteBlock,
-  NotionColor,
   NotionBlock,
+  NotionColor,
+  NotionQuoteBlock,
 } from "../../types/notion";
-
+import { logger } from "../../utils/logger-utils";
 import { renderBlocks, renderRichText } from "../../utils/render-utils";
-import { Block, CreatableBlock } from "../Block";
+
+import { BulletedListItemBlock } from "./BulletedListItemBlock";
+import { CodeBlock } from "./CodeBlock";
+import { DividerBlock } from "./DividerBlock";
+import { EmbedBlock } from "./EmbedBlock";
+import { Heading1Block } from "./Heading1Block";
+import { Heading2Block } from "./Heading2Block";
+import { Heading3Block } from "./Heading3Block";
+import { ImageBlock } from "./ImageBlock";
+import { NumberedListItemBlock } from "./NumberedListItemBlock";
+import { ParagraphBlock } from "./ParagraphBlock";
+import { ToggleBlock } from "./ToggleBlock";
+import { VideoBlock } from "./VideoBlock";
+
+const QuoteChildBlockMap = {
+  bulleted_list_item: BulletedListItemBlock,
+  code: CodeBlock,
+  divider: DividerBlock,
+  embed: EmbedBlock,
+  heading_1: Heading1Block,
+  heading_2: Heading2Block,
+  heading_3: Heading3Block,
+  image: ImageBlock,
+  numbered_list_item: NumberedListItemBlock,
+  paragraph: ParagraphBlock,
+  toggle: ToggleBlock,
+  video: VideoBlock,
+};
+
+type QuoteChildBlockType = keyof typeof QuoteChildBlockMap;
+type QuoteChildBlock =
+  QuoteChildBlockType extends keyof typeof QuoteChildBlockMap
+    ? InstanceType<(typeof QuoteChildBlockMap)[QuoteChildBlockType]>
+    : never;
 
 export class QuoteBlock {
   text: string;
@@ -26,9 +59,9 @@ export class QuoteBlock {
       return;
     }
     // Create blocks from children data.
-    let childBlocks: CreatableBlock[] = [];
+    let childBlocks: QuoteChildBlock[] = [];
     for (const child of this.children) {
-      const block = await Block.create(child);
+      const block = await this.createChildBlocks(child);
       childBlocks.push(block);
       // Run prerender if necessary()
       if ("prerender" in block) await block.prerender();
@@ -46,5 +79,23 @@ export class QuoteBlock {
       throw new Error(msg);
     }
     return `> ${this.text}`;
+  }
+
+  private async createChildBlocks(
+    params: NotionBlock
+  ): Promise<QuoteChildBlock> {
+    logger.debug(`Creating child quote block: ${params.type}`);
+    // If the block is not supported, throw an error.
+    if (!Object.keys(QuoteChildBlockMap).includes(params.type)) {
+      throw new Error(`Block not supported: ${params.type}`);
+    }
+    // Otherwise, pick a block from the allowed children and return a new
+    // instance of it.
+    const blockType = params.type as keyof typeof QuoteChildBlockMap;
+    const block = new QuoteChildBlockMap[blockType](params as any);
+    // If prerender() exists on the block instance, run it.
+    if ("prerender" in block) await block.prerender();
+    // Return the block instance.
+    return block;
   }
 }

--- a/packages/notion-post-publisher/src/utils/logger-utils.ts
+++ b/packages/notion-post-publisher/src/utils/logger-utils.ts
@@ -1,0 +1,3 @@
+import { Logger } from "../lib/Logger";
+
+export const logger = new Logger();


### PR DESCRIPTION
After much debugging, I finally identified an issue with circular dependencies (after having AI run in circles for a couple hours). I'm not sure why this wasn't causing a problem previously, as it doesn't seem like the code causing the issue changed with the latest upgrades.

The resolution of this issue is that blocks which accept and render children must redefine their own accepted children and rendering mechanism. Check out the callout and quote blocks as an example.

While this is duplicating code, it was the easiest way I could find to solve the issue. A DRYer solution could have been to have a shared function which more generic typing, but this is nice in that we can keep the typing tight and the unique rendering behavior applied to each block. 

In the end, it's a bit more work when introducing a new block that should also act as a child block in some cases, but it's more declarative and flexible.