### PR TITLE
Add two blog posts: mental model + first Cowork experiment

### DIFF
--- a/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
+++ b/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
@@ -40,9 +40,9 @@ When I need to build something serious — multi-file changes, complex architect
 
 ### rocktree and Netlify agent runners: async coding tasks
 
-There's a category I haven't talked much about yet: async coding tasks. These are coding jobs I want done without sitting in the driver's seat.
+The category I've been tinkering with for a few months is async coding tasks. These are coding jobs I want done without sitting in the driver's seat.
 
-For my work at Netlify, I use Netlify's agent runners — a tool we're constantly improving to optimize that async workflow. For side projects, I've stood up a custom agent team I call [rocktree](https://www.rocktree.ai/). Its source of truth is a GitHub Projects board: it checks for issues that are ready to work, follows a series of defined tasks to get the job done, and sends it back to me for review.
+For my work at Netlify, I tend to use Netlify's agent runners — a tool we're constantly improving to optimize that async workflow. For side projects, I've stood up a custom agent team I call [rocktree](https://www.rocktree.ai/). Its source of truth is a GitHub Projects board: it checks for issues that are ready to work, follows a series of defined tasks to get the job done, and sends it back to me for review.
 
 The artifact is a pull request — concrete code output I can review and ship.
 

--- a/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
+++ b/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
@@ -1,13 +1,13 @@
 ---
-title: Claude Cowork as a co-pilot, not an autopilot
+title: An updated mental model for choosing the right AI tool
 description: >-
-  After six months of building furiously with AI, I finally have a mental model
-  that makes sense of all these tools — and Cowork fits in a very specific spot.
+  After six months of building furiously with AI, I finally mapped out a clean
+  framework for which tool to reach for — and when.
 tags:
   - ai
   - productivity
-  - inspiration
   - developer-advice
+date: 2026-04-08
 image: /posts/260408/claude-cowork-as-a-co-pilot-not-an-autopilot-wxRov2qo.png
 seo:
   image: >-
@@ -20,15 +20,13 @@ I'd spent six months just hammering. Building apps, spinning up agents, pushing 
 
 I came back from that trip with a clearer head and [a new approach to creating and sharing](/posts/my-new-approach-to-creating-and-sharing/). Weekly themes. Video-first content. Spending max one hour a day to produce something publishable. But that plan immediately raised a new question: how do I actually use these AI tools to make that happen?
 
-That's what I've been figuring out this week.
-
 ## The problem with "just use AI"
 
 I use a lot of AI tools. Claude Code for heavy development. A thin wrapper I've built around the Claude API — I'm calling it OpenClaw — for async capture from anywhere (it runs via Telegram, which means I can use it from my phone at 6am without sitting down at a computer). A custom agent team called RockTree for certain async coding tasks. And now Cowork.
 
 The thing I kept bumping into was that I didn't have a clean mental model for _when_ to reach for which one. And without that mental model, every tool starts to feel like overhead. You spend cognitive energy deciding whether to open this app or that app, and the tools that were supposed to make you faster start making you slower.
 
-So I spent a chunk of yesterday mapping it out. And I think it breaks down cleanly along two axes: **where you are** and **how synchronous the work is**.
+So I spent a chunk of time mapping it out. And I think it breaks down cleanly along two axes: **where you are** and **how synchronous the work is**.
 
 ### OpenClaw: anywhere, async, quick capture
 
@@ -50,26 +48,14 @@ Your co-pilot is not going to fly the plane without you. You're both in the cock
 
 For me right now, that means the content engine: recording a video, transcribing it, writing a blog post, creating a thumbnail, uploading to YouTube, posting on socials. Every step of that requires human judgment at the key moments, but the execution is something I can offload. That's a Cowork job.
 
-## Replacing an app with a workflow
+## Why the distinction matters
 
-The other thing I want to talk about is paredown — a little social media filtering app I built. The idea was to ingest posts from my Twitter lists, run them through AI-powered filters, and surface only what was actually relevant to me. It worked. Kind of. It was clunky, it depended on a scraping service I was paying $30/month for, and the lists had to be public, which was its own problem.
+Before I had this framework, every new AI tool felt like it was competing with the others. Is this better than Claude Code? Should I switch? Do I need this?
 
-I'd been noodling on how to improve it, and yesterday I realized: this is a better Cowork job than an app job.
+With the two-axis model, there's no competition. They're filling different slots. When I'm away from my desk and need to capture something fast, I reach for OpenClaw — nothing else fits that slot. When I'm building something complex, I open Claude Code. When I'm at my desk working through a multi-step workflow that doesn't involve software development, I open Cowork.
 
-Part of what pushed me toward rebuilding paredown as an app originally was the [era of the personal app](/posts/era-of-the-personal-app/) mentality — and I still believe in that. But the more time I spend with Cowork, the clearer the distinction becomes. Build an app when you need to collaborate, distribute, or share the mechanism with other people. Build an app when the thing needs to run on a schedule you're not around for. 
+The cognitive overhead of choosing is gone. And that, weirdly, might be the most valuable thing the framework has given me — not some optimal allocation of AI resources, but the ability to just start working without spending five minutes deciding which tool to open.
 
-But when you're already sitting at your desk and you want to do a quick review of what's worth your attention? That's a co-pilot job. I can just say: _hey, let's look at what's out there this morning_ — and it goes and does it, shows me the results, and I decide what to do with them.
+I'm still refining this. There are edges I haven't figured out yet — RockTree fits somewhere in here, and I'm not totally sure where. But the core model is working, and it's already changing how I structure my days.
 
-I rebuilt that workflow in Cowork yesterday morning. It's not just reading my lists anymore — it also does dynamic discovery based on whatever I tell it to look for that day. It flags potential new accounts worth following. It keeps memory across sessions. And because I'm sitting there with it, I can redirect it in real time. No app needed.
-
-## Why I was skeptical and why I changed my mind
-
-I'll be honest — I initially wrote Cowork off as not for developers. I figured it was a productivity tool for non-technical users and I could just use Claude Code for everything. That was wrong.
-
-What I missed is that Cowork fills a gap that Claude Code doesn't. Code is for _building_. Cowork is for _doing_ — executing multi-step workflows where the work itself isn't software development. There's a whole category of stuff I do every day that falls into that bucket, and I'd been either doing it manually or ignoring it.
-
-The content engine I'm building this week is a perfect example. Writing a blog post, creating a thumbnail in Figma, uploading a video to YouTube, posting on three social platforms — that's not a development task. It's a repeatable workflow. And having a co-pilot run alongside me while I do it is genuinely faster than doing it alone.
-
-I don't know exactly where this goes. I'm on day one. But it has me excited in the same way that Claude Code got me excited about a year ago — this sense that the ceiling just got a lot higher. And yeah, I'm still figuring it out. But I'll keep you posted.
-
-We'll see how this goes.
+More to come.

--- a/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
+++ b/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
@@ -30,7 +30,7 @@ After spending some time mapping this out, I think it breaks down cleanly along 
 
 ### OpenClaw: async, structured capture
 
-OpenClaw is an open-source project I've built for async capture from anywhere and everyday conversations. It runs via Telegram, so it's available whether I'm on a walk, in the car, or at a coffee shop at 6am. I use it for a food journal, personal journaling, building better habits, recording events and scenarios in a structured and predictable way — anything where I want to get something into my system without sitting down at a computer.
+[OpenClaw](https://openclaw.ai/) is an open-source project I've built for async capture from anywhere and everyday conversations. It runs via Telegram, so it's available whether I'm on a walk, in the car, or at a coffee shop at 6am. I use it for a food journal, personal journaling, building better habits, recording events and scenarios in a structured and predictable way — anything where I want to get something into my system without sitting down at a computer.
 
 The artifact is always structured content stored somewhere I can access and evaluate it later. And once I post the message, I don't need to be there. That's the whole point.
 
@@ -42,7 +42,7 @@ When I need to build something serious — multi-file changes, complex architect
 
 There's a category I haven't talked much about yet: async coding tasks. These are coding jobs I want done without sitting in the driver's seat.
 
-For my work at Netlify, I use Netlify's agent runners — a tool we're constantly improving to optimize that async workflow. For side projects, I've stood up a custom agent team I call rocktree. Its source of truth is a GitHub Projects board: it checks for issues that are ready to work, follows a series of defined tasks to get the job done, and sends it back to me for review.
+For my work at Netlify, I use Netlify's agent runners — a tool we're constantly improving to optimize that async workflow. For side projects, I've stood up a custom agent team I call [rocktree](https://www.rocktree.ai/). Its source of truth is a GitHub Projects board: it checks for issues that are ready to work, follows a series of defined tasks to get the job done, and sends it back to me for review.
 
 The artifact is a pull request — concrete code output I can review and ship.
 

--- a/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
+++ b/www/src/posts/2026-04-08-an-updated-mental-model-for-choosing-the-right-ai-tool.md
@@ -1,8 +1,8 @@
 ---
 title: An updated mental model for choosing the right AI tool
 description: >-
-  After six months of building furiously with AI, I finally mapped out a clean
-  framework for which tool to reach for — and when.
+  After six months of building furiously with AI, I've developed a revised
+  framework for when and how to work with each AI tool.
 tags:
   - ai
   - productivity
@@ -14,48 +14,46 @@ seo:
     /posts/260408/claude-cowork-as-a-co-pilot-not-an-autopilot-ls-mCMmw--meta.png
 ---
 
-A few weeks back I took some PTO — part of it a solo camping trip, the kind where you actually get to sit with your thoughts for a while. And one of the things I kept turning over was this tension I'd been feeling about how I use AI.
+I took some time off in March and was able to sit for a while with my thoughts. And one of the things I kept turning to was this tension I'd been feeling about how I use AI.
 
 I'd spent six months just hammering. Building apps, spinning up agents, pushing as fast as I could. The tools had genuinely changed how I work — [AI coding finally clicked for me](/posts/ai-coding-finally-clicked/), and I'd hit that flow state I wrote about. But somewhere in there I started to notice a ceiling. Not in what I could build, but in how clearly I could think about what I _should_ build. Moving fast stops being useful when you're moving fast in every direction at once.
 
-I came back from that trip with a clearer head and [a new approach to creating and sharing](/posts/my-new-approach-to-creating-and-sharing/). Weekly themes. Video-first content. Spending max one hour a day to produce something publishable. But that plan immediately raised a new question: how do I actually use these AI tools to make that happen?
+I came back from that trip with a clearer head and [a new approach to creating and sharing](/posts/my-new-approach-to-creating-and-sharing/). Weekly themes. Video-first content. Spending max one hour a day to produce something publishable. But that plan immediately raised a new question: _How do I work with these AI tools to make that possible?_
 
 ## The problem with "just use AI"
 
-I use a lot of AI tools. Claude Code for heavy development. A thin wrapper I've built around the Claude API — I'm calling it OpenClaw — for async capture from anywhere (it runs via Telegram, which means I can use it from my phone at 6am without sitting down at a computer). A custom agent team called RockTree for certain async coding tasks. And now Cowork.
+At any given moment, I might trigger an AI task through a Telegram message, a GitHub issue, a Raycast command, a Google search, Claude directly, Claude Code CLI, and more. Each one feels reasonable in isolation, but together they create too many entry points and too many different ways of working. It makes me feel inefficient — like my head is scattered across too many modes at once.
 
-The thing I kept bumping into was that I didn't have a clean mental model for _when_ to reach for which one. And without that mental model, every tool starts to feel like overhead. You spend cognitive energy deciding whether to open this app or that app, and the tools that were supposed to make you faster start making you slower.
+What I wanted was a stronger mental model. One where, based on the working mode I'm in, I have a clearer, more singular entry point — and the right tool waiting there.
 
-So I spent a chunk of time mapping it out. And I think it breaks down cleanly along two axes: **where you are** and **how synchronous the work is**.
+After spending some time mapping this out, I think it breaks down cleanly along two axes: **how synchronous the work is** and **what the artifact looks like**. Those two things together largely determine which tool is the right fit.
 
-### OpenClaw: anywhere, async, quick capture
+### OpenClaw: async, structured capture
 
-OpenClaw lives on my phone via Telegram. That's its whole value. It doesn't matter if I'm on a walk, in the car, at a coffee shop — I can send it a message and it goes into my system with the rules already set up. I use it right now primarily as a food journal, but the point is that it's _available_. The cost of capture is basically zero.
+OpenClaw is an open-source project I've built for async capture from anywhere and everyday conversations. It runs via Telegram, so it's available whether I'm on a walk, in the car, or at a coffee shop at 6am. I use it for a food journal, personal journaling, building better habits, recording events and scenarios in a structured and predictable way — anything where I want to get something into my system without sitting down at a computer.
 
-That's the job. Quick, async, available everywhere.
+The artifact is always structured content stored somewhere I can access and evaluate it later. And once I post the message, I don't need to be there. That's the whole point.
 
-### Claude Code: at the computer, heavy dev
+### Claude Code CLI: synchronous, heavy development
 
-When I need to actually build something serious — multi-file changes, complex architecture, anything that requires sustained back-and-forth — that's Claude Code. It's synchronous in the sense that I'm in the driver's seat the whole time, but it's also capable of running without me looking at it every thirty seconds. I offload heavy cognitive work to it.
+When I need to build something serious — multi-file changes, complex architecture, anything that requires sustained back-and-forth — that's Claude Code CLI. I offload heavy cognitive work to it, but I have to be mentally in that working mode to get the most out of it. If I'm not, it feels less effective. It's synchronous adjacent: even when Claude is running, I'm close by.
 
-### Cowork: at the computer, co-pilot
+### rocktree and Netlify agent runners: async coding tasks
 
-And then there's Cowork. And this is where I've landed on what I think is the most important piece of the mental model.
+There's a category I haven't talked much about yet: async coding tasks. These are coding jobs I want done without sitting in the driver's seat.
 
-Cowork is a _co-pilot_, not an autopilot.
+For my work at Netlify, I use Netlify's agent runners — a tool we're constantly improving to optimize that async workflow. For side projects, I've stood up a custom agent team I call rocktree. Its source of truth is a GitHub Projects board: it checks for issues that are ready to work, follows a series of defined tasks to get the job done, and sends it back to me for review.
 
-Your co-pilot is not going to fly the plane without you. You're both in the cockpit. You just need some help getting from point A to point B. That's the whole thing. Cowork makes sense for work where I'm already in front of the computer and I want to move faster — repeatable processes, things with a lot of steps, anything where the bottleneck is my own bandwidth rather than my judgment.
+The artifact is a pull request — concrete code output I can review and ship.
 
-For me right now, that means the content engine: recording a video, transcribing it, writing a blog post, creating a thumbnail, uploading to YouTube, posting on socials. Every step of that requires human judgment at the key moments, but the execution is something I can offload. That's a Cowork job.
+### Cowork: synchronous, repeatable workflows
 
-## Why the distinction matters
+And then there's Cowork. What I've landed on: Cowork is a _co-pilot_, not an autopilot. You're both in the cockpit. It's there for work where I'm already at my desk and the bottleneck is bandwidth, not judgment.
 
-Before I had this framework, every new AI tool felt like it was competing with the others. Is this better than Claude Code? Should I switch? Do I need this?
+One example is the content engine I'm building — recording a video, transcribing it, writing a blog post, creating a thumbnail, uploading to YouTube, posting on socials. Another is filtering the noise out of social media timelines, which I wrote about in [my first experiment with Claude Cowork](/posts/my-first-experiment-with-claude-cowork/). Every step requires human judgment at the key moments, but the execution is something I can offload.
 
-With the two-axis model, there's no competition. They're filling different slots. When I'm away from my desk and need to capture something fast, I reach for OpenClaw — nothing else fits that slot. When I'm building something complex, I open Claude Code. When I'm at my desk working through a multi-step workflow that doesn't involve software development, I open Cowork.
+## Still refining
 
-The cognitive overhead of choosing is gone. And that, weirdly, might be the most valuable thing the framework has given me — not some optimal allocation of AI resources, but the ability to just start working without spending five minutes deciding which tool to open.
+This model is designed to minimize the cognitive overhead of choosing and to keep me focused on getting work done based on the mode I'm in. When I'm capturing on the go, I reach for OpenClaw. When I have async coding work, rocktree or Netlify's agent runners handle it. When I'm building something serious, I open Claude Code CLI. When I'm executing a multi-step workflow at my desk, I open Cowork.
 
-I'm still refining this. There are edges I haven't figured out yet — RockTree fits somewhere in here, and I'm not totally sure where. But the core model is working, and it's already changing how I structure my days.
-
-More to come.
+There are still edges I'm working out. But having the model at all has already reduced the friction of just getting started — I'm not spending five minutes deciding which tool to open. I just start.

--- a/www/src/posts/2026-04-08-claude-cowork-as-a-co-pilot-not-an-autopilot.md
+++ b/www/src/posts/2026-04-08-claude-cowork-as-a-co-pilot-not-an-autopilot.md
@@ -8,6 +8,10 @@ tags:
   - productivity
   - inspiration
   - developer-advice
+image: /posts/260408/claude-cowork-as-a-co-pilot-not-an-autopilot-wxRov2qo.png
+seo:
+  image: >-
+    /posts/260408/claude-cowork-as-a-co-pilot-not-an-autopilot-ls-mCMmw--meta.png
 ---
 
 A few weeks back I took some PTO — part of it a solo camping trip, the kind where you actually get to sit with your thoughts for a while. And one of the things I kept turning over was this tension I'd been feeling about how I use AI.

--- a/www/src/posts/2026-04-08-claude-cowork-as-a-co-pilot-not-an-autopilot.md
+++ b/www/src/posts/2026-04-08-claude-cowork-as-a-co-pilot-not-an-autopilot.md
@@ -1,0 +1,71 @@
+---
+title: Claude Cowork as a co-pilot, not an autopilot
+description: >-
+  After six months of building furiously with AI, I finally have a mental model
+  that makes sense of all these tools — and Cowork fits in a very specific spot.
+tags:
+  - ai
+  - productivity
+  - inspiration
+  - developer-advice
+---
+
+A few weeks back I took some PTO — part of it a solo camping trip, the kind where you actually get to sit with your thoughts for a while. And one of the things I kept turning over was this tension I'd been feeling about how I use AI.
+
+I'd spent six months just hammering. Building apps, spinning up agents, pushing as fast as I could. The tools had genuinely changed how I work — [AI coding finally clicked for me](/posts/ai-coding-finally-clicked/), and I'd hit that flow state I wrote about. But somewhere in there I started to notice a ceiling. Not in what I could build, but in how clearly I could think about what I _should_ build. Moving fast stops being useful when you're moving fast in every direction at once.
+
+I came back from that trip with a clearer head and [a new approach to creating and sharing](/posts/my-new-approach-to-creating-and-sharing/). Weekly themes. Video-first content. Spending max one hour a day to produce something publishable. But that plan immediately raised a new question: how do I actually use these AI tools to make that happen?
+
+That's what I've been figuring out this week.
+
+## The problem with "just use AI"
+
+I use a lot of AI tools. Claude Code for heavy development. A thin wrapper I've built around the Claude API — I'm calling it OpenClaw — for async capture from anywhere (it runs via Telegram, which means I can use it from my phone at 6am without sitting down at a computer). A custom agent team called RockTree for certain async coding tasks. And now Cowork.
+
+The thing I kept bumping into was that I didn't have a clean mental model for _when_ to reach for which one. And without that mental model, every tool starts to feel like overhead. You spend cognitive energy deciding whether to open this app or that app, and the tools that were supposed to make you faster start making you slower.
+
+So I spent a chunk of yesterday mapping it out. And I think it breaks down cleanly along two axes: **where you are** and **how synchronous the work is**.
+
+### OpenClaw: anywhere, async, quick capture
+
+OpenClaw lives on my phone via Telegram. That's its whole value. It doesn't matter if I'm on a walk, in the car, at a coffee shop — I can send it a message and it goes into my system with the rules already set up. I use it right now primarily as a food journal, but the point is that it's _available_. The cost of capture is basically zero.
+
+That's the job. Quick, async, available everywhere.
+
+### Claude Code: at the computer, heavy dev
+
+When I need to actually build something serious — multi-file changes, complex architecture, anything that requires sustained back-and-forth — that's Claude Code. It's synchronous in the sense that I'm in the driver's seat the whole time, but it's also capable of running without me looking at it every thirty seconds. I offload heavy cognitive work to it.
+
+### Cowork: at the computer, co-pilot
+
+And then there's Cowork. And this is where I've landed on what I think is the most important piece of the mental model.
+
+Cowork is a _co-pilot_, not an autopilot.
+
+Your co-pilot is not going to fly the plane without you. You're both in the cockpit. You just need some help getting from point A to point B. That's the whole thing. Cowork makes sense for work where I'm already in front of the computer and I want to move faster — repeatable processes, things with a lot of steps, anything where the bottleneck is my own bandwidth rather than my judgment.
+
+For me right now, that means the content engine: recording a video, transcribing it, writing a blog post, creating a thumbnail, uploading to YouTube, posting on socials. Every step of that requires human judgment at the key moments, but the execution is something I can offload. That's a Cowork job.
+
+## Replacing an app with a workflow
+
+The other thing I want to talk about is paredown — a little social media filtering app I built. The idea was to ingest posts from my Twitter lists, run them through AI-powered filters, and surface only what was actually relevant to me. It worked. Kind of. It was clunky, it depended on a scraping service I was paying $30/month for, and the lists had to be public, which was its own problem.
+
+I'd been noodling on how to improve it, and yesterday I realized: this is a better Cowork job than an app job.
+
+Part of what pushed me toward rebuilding paredown as an app originally was the [era of the personal app](/posts/era-of-the-personal-app/) mentality — and I still believe in that. But the more time I spend with Cowork, the clearer the distinction becomes. Build an app when you need to collaborate, distribute, or share the mechanism with other people. Build an app when the thing needs to run on a schedule you're not around for. 
+
+But when you're already sitting at your desk and you want to do a quick review of what's worth your attention? That's a co-pilot job. I can just say: _hey, let's look at what's out there this morning_ — and it goes and does it, shows me the results, and I decide what to do with them.
+
+I rebuilt that workflow in Cowork yesterday morning. It's not just reading my lists anymore — it also does dynamic discovery based on whatever I tell it to look for that day. It flags potential new accounts worth following. It keeps memory across sessions. And because I'm sitting there with it, I can redirect it in real time. No app needed.
+
+## Why I was skeptical and why I changed my mind
+
+I'll be honest — I initially wrote Cowork off as not for developers. I figured it was a productivity tool for non-technical users and I could just use Claude Code for everything. That was wrong.
+
+What I missed is that Cowork fills a gap that Claude Code doesn't. Code is for _building_. Cowork is for _doing_ — executing multi-step workflows where the work itself isn't software development. There's a whole category of stuff I do every day that falls into that bucket, and I'd been either doing it manually or ignoring it.
+
+The content engine I'm building this week is a perfect example. Writing a blog post, creating a thumbnail in Figma, uploading a video to YouTube, posting on three social platforms — that's not a development task. It's a repeatable workflow. And having a co-pilot run alongside me while I do it is genuinely faster than doing it alone.
+
+I don't know exactly where this goes. I'm on day one. But it has me excited in the same way that Claude Code got me excited about a year ago — this sense that the ceiling just got a lot higher. And yeah, I'm still figuring it out. But I'll keep you posted.
+
+We'll see how this goes.

--- a/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
+++ b/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
@@ -13,38 +13,38 @@ seo:
   image: /posts/260409/my-first-experiment-with-claude-cowork-xl2gDrTx--meta.png
 ---
 
-Yesterday I wrote about [the mental model I've landed on for choosing between AI tools](/posts/an-updated-mental-model-for-choosing-the-right-ai-tool/). The short version: Cowork is a co-pilot, not an autopilot. It's for work where you're already at your desk and the bottleneck is bandwidth, not judgment.
+Yesterday I wrote about [the mental model I've landed on for how I work with AI tools](/posts/an-updated-mental-model-for-choosing-the-right-ai-tool/) based on the working mode I'm in. One thing I'm experimenting with right now is how I work with Claude Cowork. After a few initial experiments, I'm immediately seeing Cowork as a co-pilot, not an autopilot — there when I'm at my desk hammering on repeatable tasks, freeing me to put my time toward work that requires judgment rather than plain execution.
 
-Today I want to talk about what it actually looked like to use that model in practice — because the first real test surprised me.
+I want to share a little about the first experiment I ran with Cowork, which has surprised me at how effective it has been.
 
 ## Replacing an app with a workflow
 
-A while back I built a little social media filtering tool called paredown. The idea was to ingest posts from my Twitter lists, run them through AI-powered filters, and surface only what was actually relevant to me. It worked. Kind of. It was clunky, it depended on a scraping service I was paying $30/month for, and the lists had to be public, which was its own problem.
+A while back I built a little social media filtering tool called paredown. The idea was to ingest posts from my Twitter lists, run them through AI-powered filters, and surface only what was actually relevant to me. It actually did a decent job — finding posts and scoring them based on the relevance of the unique context I'd configured.
 
-I'd been noodling on how to improve it. More filters, better sources, less friction. And what I realized one morning this week: this is a better Cowork job than an app job.
+But it wasn't as effective as I'd hoped overall, and it was clunky. It depended on a scraping service I was paying $30/month for, and the lists had to be public, which was its own problem. The friction kept me from actually using it.
 
-That distinction — app job vs. co-pilot job — is worth unpacking. Part of what pushed me toward rebuilding paredown as an app originally was the [era of the personal app](/posts/era-of-the-personal-app/) mentality — and I still believe in that. Build something, own it, run it. But the more time I spend thinking about when apps make sense, the clearer the line becomes.
+### Searching for less friction
 
-Build an app when you need to collaborate, distribute, or share the mechanism with other people. Build an app when the thing needs to run on a schedule you're not around for. But when you're already sitting at your desk and you want to do a quick review of what's worth your attention? That's a co-pilot job.
+I'd been noodling on how to improve it: more filters, better sources, less friction. And I had a hypothesis that this might be something Cowork could handle better than the app I'd built.
 
-So I rebuilt the whole thing as a Cowork workflow in a morning. And it's not just reading my lists anymore — it also does dynamic discovery based on whatever I tell it to look for that day. It flags potential new accounts worth following. It keeps memory across sessions. And because I'm sitting there with it, I can redirect it in real time if something interesting comes up.
+So I rebuilt the whole thing as a Cowork workflow in a morning. It's not just reading my lists anymore — it also does dynamic discovery based on whatever I tell it to look for that day, flags potential new accounts worth following, and keeps memory across sessions. And because it's right in front of me, if I need to tweak something, I just start a new conversation and the scheduled task runs a little differently the next time.
 
-No app. No scraping service. No $30/month.
+### AI app vs. Cowork job
 
-## Why I was skeptical
+That distinction — app job vs. co-pilot job — is worth unpacking. Part of what pushed me toward rebuilding paredown as an app originally was the [era of the personal app](/posts/era-of-the-personal-app/) mentality — and I still believe in that. But the more time I spend thinking about when apps make sense, the clearer the line becomes.
 
-I'll be honest — I initially wrote Cowork off as not for developers. I figured it was a productivity tool for non-technical users and I could just use Claude Code for everything. That was wrong.
+Build an app when you need to collaborate, distribute, or share the mechanism with other people. Build an app when the thing needs to run on a schedule you're not around for. Cowork has immediately felt like the better fit here because this is work I'm going to action on while I'm sitting at my desk — and it doesn't matter if that job ran while I was taking a day off, because day-old social posts aren't worth responding to anyway.
 
-What I missed is that Cowork fills a gap that Claude Code doesn't. Code is for _building_. Cowork is for _doing_ — executing multi-step workflows where the work itself isn't software development. There's a whole category of stuff I do every day that falls into that bucket, and I'd been either doing it manually or ignoring it.
+## I was skeptical about Claude Cowork
 
-The content engine I'm building this week is the clearest example. Writing a blog post, creating a thumbnail in Figma, uploading a video to YouTube, posting on three social platforms — that's not a development task. It's a repeatable workflow. And having a co-pilot run alongside me while I do it is genuinely faster than doing it alone.
+I initially wrote Cowork off as not for developers — not for me. I figured it was a productivity tool for non-technical users and I could just use Claude Code for everything. That was wrong.
 
-## What I'm watching
+What I missed is that Cowork fills a gap Claude Code doesn't. Code is for _building_. Cowork is for _doing_ — executing multi-step workflows where the work itself isn't software development. There's a whole category of stuff I do every day that falls into that bucket, and I'd been either doing it manually or ignoring it.
 
-I'm on day one. Which means I don't have strong conclusions yet — just early signals.
+The content engine I'm building this week is the clearest example. Writing a blog post, creating a thumbnail, uploading a video to YouTube, posting on three social platforms — that's not a development task. It's a repeatable workflow. And having a co-pilot run alongside me while I do it is genuinely faster than doing it alone.
 
-The one I keep coming back to: having the right mental model for a tool changes how useful the tool is. I'd been using Cowork with a vague sense of what it was for, and that vagueness made it feel optional. Now that it has a clear slot in my stack, I reach for it without thinking. The friction is gone.
+## At the beginning of the Cowork journey
 
-That's usually how it goes with tools that actually stick. You don't convince yourself to use them — you just find yourself using them.
+I'm writing this after just a couple of days with this new mental model, so I don't have strong conclusions yet — but the early signals are strong. I'm going to keep looking for new use cases where Cowork can remove repeatable tasks from my day and help me stay focused on work that actually requires my thinking.
 
-I'll keep you posted on how this develops. Lots more to build out.
+Much more to come. Let's get back to building.

--- a/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
+++ b/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
@@ -1,13 +1,16 @@
 ---
 title: My first experiment with Claude Cowork
 description: >-
-  I'd written Cowork off as a tool for non-developers. Then I rebuilt a $30/month
-  app as a morning workflow and changed my mind.
+  I'd written Cowork off as a tool for non-developers. Then I rebuilt a
+  $30/month app as a morning workflow and changed my mind.
 tags:
   - ai
   - productivity
   - developer-advice
-date: 2026-04-09
+date: 2026-04-09T00:00:00.000Z
+image: /posts/260409/my-first-experiment-with-claude-cowork-aIp50euM.png
+seo:
+  image: /posts/260409/my-first-experiment-with-claude-cowork-xl2gDrTx--meta.png
 ---
 
 Yesterday I wrote about [the mental model I've landed on for choosing between AI tools](/posts/an-updated-mental-model-for-choosing-the-right-ai-tool/). The short version: Cowork is a co-pilot, not an autopilot. It's for work where you're already at your desk and the bottleneck is bandwidth, not judgment.

--- a/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
+++ b/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
@@ -47,4 +47,4 @@ The content engine I'm building this week is the clearest example. Writing a blo
 
 I'm writing this after just a couple of days with this new mental model, so I don't have strong conclusions yet — but the early signals are strong. I'm going to keep looking for new use cases where Cowork can remove repeatable tasks from my day and help me stay focused on work that actually requires my thinking.
 
-Much more to come. Let's get back to building.
+Much more to come. And now, back to building!

--- a/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
+++ b/www/src/posts/2026-04-09-my-first-experiment-with-claude-cowork.md
@@ -1,0 +1,47 @@
+---
+title: My first experiment with Claude Cowork
+description: >-
+  I'd written Cowork off as a tool for non-developers. Then I rebuilt a $30/month
+  app as a morning workflow and changed my mind.
+tags:
+  - ai
+  - productivity
+  - developer-advice
+date: 2026-04-09
+---
+
+Yesterday I wrote about [the mental model I've landed on for choosing between AI tools](/posts/an-updated-mental-model-for-choosing-the-right-ai-tool/). The short version: Cowork is a co-pilot, not an autopilot. It's for work where you're already at your desk and the bottleneck is bandwidth, not judgment.
+
+Today I want to talk about what it actually looked like to use that model in practice — because the first real test surprised me.
+
+## Replacing an app with a workflow
+
+A while back I built a little social media filtering tool called paredown. The idea was to ingest posts from my Twitter lists, run them through AI-powered filters, and surface only what was actually relevant to me. It worked. Kind of. It was clunky, it depended on a scraping service I was paying $30/month for, and the lists had to be public, which was its own problem.
+
+I'd been noodling on how to improve it. More filters, better sources, less friction. And what I realized one morning this week: this is a better Cowork job than an app job.
+
+That distinction — app job vs. co-pilot job — is worth unpacking. Part of what pushed me toward rebuilding paredown as an app originally was the [era of the personal app](/posts/era-of-the-personal-app/) mentality — and I still believe in that. Build something, own it, run it. But the more time I spend thinking about when apps make sense, the clearer the line becomes.
+
+Build an app when you need to collaborate, distribute, or share the mechanism with other people. Build an app when the thing needs to run on a schedule you're not around for. But when you're already sitting at your desk and you want to do a quick review of what's worth your attention? That's a co-pilot job.
+
+So I rebuilt the whole thing as a Cowork workflow in a morning. And it's not just reading my lists anymore — it also does dynamic discovery based on whatever I tell it to look for that day. It flags potential new accounts worth following. It keeps memory across sessions. And because I'm sitting there with it, I can redirect it in real time if something interesting comes up.
+
+No app. No scraping service. No $30/month.
+
+## Why I was skeptical
+
+I'll be honest — I initially wrote Cowork off as not for developers. I figured it was a productivity tool for non-technical users and I could just use Claude Code for everything. That was wrong.
+
+What I missed is that Cowork fills a gap that Claude Code doesn't. Code is for _building_. Cowork is for _doing_ — executing multi-step workflows where the work itself isn't software development. There's a whole category of stuff I do every day that falls into that bucket, and I'd been either doing it manually or ignoring it.
+
+The content engine I'm building this week is the clearest example. Writing a blog post, creating a thumbnail in Figma, uploading a video to YouTube, posting on three social platforms — that's not a development task. It's a repeatable workflow. And having a co-pilot run alongside me while I do it is genuinely faster than doing it alone.
+
+## What I'm watching
+
+I'm on day one. Which means I don't have strong conclusions yet — just early signals.
+
+The one I keep coming back to: having the right mental model for a tool changes how useful the tool is. I'd been using Cowork with a vague sense of what it was for, and that vagueness made it feel optional. Now that it has a clear slot in my stack, I reach for it without thinking. The friction is gone.
+
+That's usually how it goes with tools that actually stick. You don't convince yourself to use them — you just find yourself using them.
+
+I'll keep you posted on how this develops. Lots more to build out.


### PR DESCRIPTION
## Posts

**2026-04-08 — An updated mental model for choosing the right AI tool**
Covers the two-axis framework (where you are × how synchronous), where OpenClaw, Claude Code, and Cowork each fit, and the co-pilot vs autopilot distinction.

**2026-04-09 — My first experiment with Claude Cowork**
Covers replacing the paredown social filtering app with a Cowork workflow, the app-vs-workflow decision, and why I was initially skeptical of Cowork as a developer.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)